### PR TITLE
Add one-line install scripts (install.sh + install.ps1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,9 @@ jobs:
         with:
           merge-multiple: true
 
+      - name: Generate checksums
+        run: sha256sum lumitide-linux lumitide-macos lumitide-windows.exe > sha256sums.txt
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -102,5 +105,6 @@ jobs:
             lumitide-installer.exe
             lumitide-linux
             lumitide-macos
+            sha256sums.txt
           body_path: .github/RELEASE_NOTES.md
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ Stream lossless audio from your Tidal account directly in the terminal, with alb
 
 ## Installation
 
+### Quick install (one-liner)
+
+**Linux / macOS:**
+```sh
+curl -fsSL https://raw.githubusercontent.com/BreakLime/lumitide/main/install.sh | bash
+```
+
+**Windows (PowerShell 7+):**
+```powershell
+irm https://raw.githubusercontent.com/BreakLime/lumitide/main/install.ps1 | iex
+```
+
+Both scripts download the latest prebuilt binary for your platform and drop it somewhere on your `PATH`. Pin a specific release with `--version vX.Y.Z` (bash) or `-Version vX.Y.Z` (PowerShell). Uninstall is a single-file delete: remove `~/.local/bin/lumitide` on Linux/macOS, or `%LOCALAPPDATA%\Programs\lumitide` on Windows.
+
 ### Download (recommended)
 
 Grab the latest release for your platform from the [Releases](https://github.com/BreakLime/lumitide/releases) page.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,20 @@ curl -fsSL https://raw.githubusercontent.com/BreakLime/lumitide/main/install.sh 
 irm https://raw.githubusercontent.com/BreakLime/lumitide/main/install.ps1 | iex
 ```
 
-Both scripts download the latest prebuilt binary for your platform and drop it somewhere on your `PATH`. Pin a specific release with `--version vX.Y.Z` (bash) or `-Version vX.Y.Z` (PowerShell). Uninstall is a single-file delete: remove `~/.local/bin/lumitide` on Linux/macOS, or `%LOCALAPPDATA%\Programs\lumitide` on Windows.
+Both scripts download the latest prebuilt binary for your platform and drop it somewhere on your `PATH`.
+
+Pin a specific release:
+```sh
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/BreakLime/lumitide/main/install.sh | bash -s -- --version vX.Y.Z
+
+# Windows (PowerShell 7+)
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/BreakLime/lumitide/main/install.ps1))) -Version vX.Y.Z
+```
+
+To uninstall, remove the binary and undo the changes the installer made:
+- **Linux / macOS:** `rm ~/.local/bin/lumitide`
+- **Windows:** delete `%LOCALAPPDATA%\Programs\lumitide`, remove the `Lumitide` shortcut from `%APPDATA%\Microsoft\Windows\Start Menu\Programs`, and remove `%LOCALAPPDATA%\Programs\lumitide` from your User PATH (Settings → System → About → Advanced system settings → Environment Variables).
 
 ### Download (recommended)
 

--- a/install.ps1
+++ b/install.ps1
@@ -76,7 +76,7 @@ $url = if ($Version) {
 }
 
 # --- Download ---
-$tmp = Join-Path $env:TEMP ("lumitide-" + [guid]::NewGuid() + ".exe")
+$tmp = Join-Path $InstallDir ("lumitide-" + [guid]::NewGuid() + ".exe")
 try {
     $prev = $ProgressPreference
     $ProgressPreference = if ($VerboseLog) { 'Continue' } else { 'SilentlyContinue' }

--- a/install.ps1
+++ b/install.ps1
@@ -24,6 +24,12 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# #Requires -Version 7.0 is silently ignored when piped through iex — check explicitly.
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    Write-Host "error: PowerShell 7+ is required. Download it from https://aka.ms/powershell" -ForegroundColor Red
+    exit 1
+}
+
 $Repo = 'BreakLime/lumitide'
 $Asset = 'lumitide-windows.exe'
 
@@ -99,6 +105,27 @@ try {
         Abort "downloaded file is empty: $url"
     }
 
+    # --- Checksum verification ---
+    $checksumsUrl = $url -replace '[^/]+$', 'sha256sums.txt'
+    $tmpSums = Join-Path $env:TEMP ("lumitide-sums-" + [guid]::NewGuid() + ".txt")
+    try {
+        Invoke-WebRequest -Uri $checksumsUrl -OutFile $tmpSums -UseBasicParsing -ErrorAction Stop
+        $expected = (Get-Content $tmpSums | Where-Object { $_ -match "\s$([regex]::Escape($Asset))$" }) -replace '^(\S+)\s.*', '$1'
+        if ($expected) {
+            $actual = (Get-FileHash $tmp -Algorithm SHA256).Hash.ToLower()
+            if ($actual -ne $expected.ToLower()) {
+                Abort "checksum mismatch for $Asset`n  expected: $expected`n  got:      $actual"
+            }
+            if ($VerboseLog) { Write-Host "Checksum OK: $actual" }
+        } else {
+            Write-Host "warning: $Asset not found in sha256sums.txt — skipping verification" -ForegroundColor Yellow
+        }
+    } catch {
+        Write-Host "warning: could not fetch sha256sums.txt — skipping checksum verification" -ForegroundColor Yellow
+    } finally {
+        if (Test-Path $tmpSums) { Remove-Item -Force $tmpSums -ErrorAction SilentlyContinue }
+    }
+
     # --- Install (atomic-ish) ---
     $dest = Join-Path $InstallDir 'lumitide.exe'
     try {
@@ -114,7 +141,7 @@ try {
 $pathAdded = $false
 $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
 $userPathEntries = if ($userPath) { $userPath -split ';' } else { @() }
-if ($userPathEntries -notcontains $InstallDir) {
+if ($userPathEntries -inotcontains $InstallDir) {
     $new = if ([string]::IsNullOrEmpty($userPath)) {
         $InstallDir
     } else {

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,164 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Windows installer for lumitide. Pure PowerShell, no Inno Setup required.
+.DESCRIPTION
+    Downloads the portable lumitide-windows.exe release asset, installs it
+    user-scoped under $env:LOCALAPPDATA\Programs\lumitide, updates the User
+    PATH, and (optionally) creates a Start Menu shortcut.
+
+    First install:  irm https://raw.githubusercontent.com/BreakLime/lumitide/main/install.ps1 | iex
+    Re-install:     .\install.ps1
+    Pin version:    .\install.ps1 -Version v1.0.8
+    Skip shortcut:  .\install.ps1 -NoShortcut
+    Verbose:        .\install.ps1 -VerboseLog
+#>
+#Requires -Version 7.0
+
+param(
+    [string]$Version,
+    [string]$Prefix,
+    [switch]$NoShortcut,
+    [switch]$VerboseLog
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'BreakLime/lumitide'
+$Asset = 'lumitide-windows.exe'
+
+function Abort([string]$msg) {
+    Write-Host "error: $msg" -ForegroundColor Red
+    exit 1
+}
+
+# --- Arch guard ---
+if (-not [Environment]::Is64BitOperatingSystem) {
+    Abort "no prebuilt binary for 32-bit Windows — build from source: https://github.com/$Repo#build-from-source"
+}
+
+# --- Refuse if an Inno wizard install already exists ---
+# Inno's lumitide.iss uses DefaultDirName={autopf}\Lumitide, so per-machine
+# installs land under Program Files (x86/native) and per-user installs land
+# under $env:LOCALAPPDATA\Programs\Lumitide. Check all three.
+$innoCandidates = @(
+    (Join-Path $env:ProgramFiles        'Lumitide\lumitide.exe'),
+    (Join-Path ${env:ProgramFiles(x86)} 'Lumitide\lumitide.exe'),
+    (Join-Path $env:LOCALAPPDATA        'Programs\Lumitide\lumitide.exe')
+) | Where-Object { $_ -and (Test-Path $_) }
+
+if ($innoCandidates) {
+    $pathList = ($innoCandidates | ForEach-Object { "  $_" }) -join "`n"
+    Abort @"
+detected an existing Lumitide wizard install at:
+$pathList
+uninstall it first from Settings > Apps > Installed apps, then re-run this script.
+(to keep using the wizard installer instead, skip this script and download
+ lumitide-installer.exe from https://github.com/$Repo/releases)
+"@
+}
+
+# --- Resolve install dir ---
+$InstallDir = if ($Prefix) {
+    $Prefix
+} elseif ($env:LUMITIDE_PREFIX) {
+    $env:LUMITIDE_PREFIX
+} else {
+    Join-Path $env:LOCALAPPDATA 'Programs\lumitide'
+}
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+# --- Download URL ---
+$url = if ($Version) {
+    "https://github.com/$Repo/releases/download/$Version/$Asset"
+} else {
+    "https://github.com/$Repo/releases/latest/download/$Asset"
+}
+
+# --- Download ---
+$tmp = Join-Path $env:TEMP ("lumitide-" + [guid]::NewGuid() + ".exe")
+try {
+    $prev = $ProgressPreference
+    $ProgressPreference = if ($VerboseLog) { 'Continue' } else { 'SilentlyContinue' }
+    if ($VerboseLog) {
+        Write-Host "Downloading $url"
+    } else {
+        Write-Host -NoNewline "Downloading lumitide... "
+    }
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $tmp -UseBasicParsing
+    } catch {
+        if (-not $VerboseLog) { Write-Host "FAILED" -ForegroundColor Red }
+        Abort "download failed: $url`n$($_.Exception.Message)"
+    } finally {
+        $ProgressPreference = $prev
+    }
+    if (-not $VerboseLog) { Write-Host "done" }
+
+    if (-not (Test-Path $tmp) -or (Get-Item $tmp).Length -eq 0) {
+        Abort "downloaded file is empty: $url"
+    }
+
+    # --- Install (atomic-ish) ---
+    $dest = Join-Path $InstallDir 'lumitide.exe'
+    try {
+        Move-Item -Force -Path $tmp -Destination $dest
+    } catch {
+        Abort "could not replace $dest — is lumitide running? close it and re-run.`n$($_.Exception.Message)"
+    }
+} finally {
+    if (Test-Path $tmp) { Remove-Item -Force $tmp -ErrorAction SilentlyContinue }
+}
+
+# --- PATH update (user scope, no admin) ---
+$pathAdded = $false
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+$userPathEntries = if ($userPath) { $userPath -split ';' } else { @() }
+if ($userPathEntries -notcontains $InstallDir) {
+    $new = if ([string]::IsNullOrEmpty($userPath)) {
+        $InstallDir
+    } else {
+        "$userPath;$InstallDir"
+    }
+    [Environment]::SetEnvironmentVariable('Path', $new, 'User')
+    $env:Path = "$env:Path;$InstallDir"
+    $pathAdded = $true
+}
+
+# --- Start Menu shortcut (best effort) ---
+if (-not $NoShortcut) {
+    try {
+        $startMenu = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+        if (-not (Test-Path $startMenu)) {
+            New-Item -ItemType Directory -Force -Path $startMenu | Out-Null
+        }
+        $lnk = Join-Path $startMenu 'Lumitide.lnk'
+        $shell = New-Object -ComObject WScript.Shell
+        $s = $shell.CreateShortcut($lnk)
+        $s.TargetPath = $dest
+        $s.WorkingDirectory = $InstallDir
+        $s.IconLocation = $dest
+        $s.Save()
+    } catch {
+        Write-Host "warning: could not create Start Menu shortcut: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
+# --- Self-check: `lumitide --help` exits 0 iff the binary loads cleanly ---
+Write-Host "Installed lumitide -> $dest"
+try {
+    & $dest --help *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "warning: '$dest --help' exited nonzero" -ForegroundColor Yellow
+    }
+} catch {
+    Write-Host "warning: self-check failed: $($_.Exception.Message)" -ForegroundColor Yellow
+}
+
+if ($pathAdded) {
+    Write-Host ""
+    Write-Host "Added $InstallDir to your User PATH. Open a new terminal to pick it up."
+}
+
+Write-Host ""
+Write-Host "Run 'lumitide' to start."

--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,8 @@ else
 	URL="https://github.com/$REPO/releases/latest/download/$ASSET"
 fi
 
-TMP="$(mktemp)"
+mkdir -p "$INSTALL_DIR"
+TMP="$(mktemp "$INSTALL_DIR/lumitide.XXXXXX")"
 trap 'rm -f "$TMP"' EXIT
 
 if command -v curl >/dev/null 2>&1; then
@@ -90,7 +91,6 @@ fi
 
 [ -s "$TMP" ] || die "downloaded file is empty: $URL"
 
-mkdir -p "$INSTALL_DIR"
 chmod +x "$TMP"
 mv "$TMP" "$INSTALL_DIR/lumitide"
 

--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,38 @@ fi
 
 [ -s "$TMP" ] || die "downloaded file is empty: $URL"
 
+# --- Checksum verification ---
+CHECKSUMS_URL="${URL%/*}/sha256sums.txt"
+TMP_SUMS="$(mktemp)"
+trap 'rm -f "$TMP" "$TMP_SUMS"' EXIT
+GOT_SUMS=0
+if command -v curl >/dev/null 2>&1; then
+	curl -fsSL --retry 2 -o "$TMP_SUMS" "$CHECKSUMS_URL" 2>/dev/null && GOT_SUMS=1 || true
+elif command -v wget >/dev/null 2>&1; then
+	wget -q -O "$TMP_SUMS" "$CHECKSUMS_URL" 2>/dev/null && GOT_SUMS=1 || true
+fi
+if [ "$GOT_SUMS" = 1 ] && [ -s "$TMP_SUMS" ]; then
+	EXPECTED="$(grep "  $ASSET\$" "$TMP_SUMS" | awk '{print $1}')"
+	if [ -n "$EXPECTED" ]; then
+		if command -v sha256sum >/dev/null 2>&1; then
+			ACTUAL="$(sha256sum "$TMP" | awk '{print $1}')"
+		elif command -v shasum >/dev/null 2>&1; then
+			ACTUAL="$(shasum -a 256 "$TMP" | awk '{print $1}')"
+		else
+			echo "warning: no sha256 tool found — skipping checksum verification" >&2
+			EXPECTED=""
+		fi
+		if [ -n "$EXPECTED" ]; then
+			[ "$EXPECTED" = "$ACTUAL" ] || die "checksum mismatch for $ASSET (expected $EXPECTED, got $ACTUAL)"
+			[ "$VERBOSE" = 1 ] && echo "Checksum OK: $ACTUAL"
+		fi
+	else
+		echo "warning: $ASSET not found in sha256sums.txt — skipping verification" >&2
+	fi
+else
+	echo "warning: could not fetch sha256sums.txt — skipping checksum verification" >&2
+fi
+
 chmod +x "$TMP"
 mv "$TMP" "$INSTALL_DIR/lumitide"
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+REPO="BreakLime/lumitide"
+INSTALL_DIR="${LUMITIDE_PREFIX:-$HOME/.local/bin}"
+VERSION=""
+VERBOSE=0
+
+die() { echo "error: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--verbose) VERBOSE=1 ;;
+		--version)
+			shift
+			[ $# -gt 0 ] || die "--version requires a tag argument (e.g. --version v1.0.8)"
+			VERSION="$1"
+			;;
+		--version=*) VERSION="${1#--version=}" ;;
+		-h|--help)
+			cat <<EOF
+Usage: install.sh [--version vX.Y.Z] [--verbose]
+
+Downloads the latest (or pinned) lumitide release binary for the current
+platform and installs it to \$LUMITIDE_PREFIX (default: \$HOME/.local/bin).
+
+Options:
+  --version vX.Y.Z   Pin a specific release tag instead of latest
+  --verbose          Show download progress
+  -h, --help         Show this help
+EOF
+			exit 0
+			;;
+		*) die "unknown argument: $1" ;;
+	esac
+	shift
+done
+
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os/$arch" in
+	Linux/x86_64)   ASSET="lumitide-linux" ;;
+	Darwin/x86_64)  ASSET="lumitide-macos" ;;
+	Darwin/arm64)
+		ASSET="lumitide-macos"
+		echo "note: Apple Silicon detected; the x86_64 binary will run under Rosetta 2." >&2
+		;;
+	*)
+		die "no prebuilt binary for $os/$arch — build from source: https://github.com/$REPO#build-from-source"
+		;;
+esac
+
+if [ -n "$VERSION" ]; then
+	URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET"
+else
+	URL="https://github.com/$REPO/releases/latest/download/$ASSET"
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+if command -v curl >/dev/null 2>&1; then
+	if [ "$VERBOSE" = 1 ]; then
+		echo "Downloading $URL"
+		curl -fL --retry 3 --retry-delay 2 -o "$TMP" "$URL"
+	else
+		printf "Downloading lumitide... "
+		if ! curl -fsSL --retry 3 --retry-delay 2 -o "$TMP" "$URL"; then
+			echo "FAILED"
+			die "download failed: $URL"
+		fi
+		echo "done"
+	fi
+elif command -v wget >/dev/null 2>&1; then
+	if [ "$VERBOSE" = 1 ]; then
+		echo "Downloading $URL"
+		wget -O "$TMP" "$URL"
+	else
+		printf "Downloading lumitide... "
+		if ! wget -q -O "$TMP" "$URL"; then
+			echo "FAILED"
+			die "download failed: $URL"
+		fi
+		echo "done"
+	fi
+else
+	die "need curl or wget on PATH"
+fi
+
+[ -s "$TMP" ] || die "downloaded file is empty: $URL"
+
+mkdir -p "$INSTALL_DIR"
+chmod +x "$TMP"
+mv "$TMP" "$INSTALL_DIR/lumitide"
+
+# Smoke-test: `lumitide --help` exits 0 iff the binary loaded its shared
+# libs successfully. Keep the outer exit 0 either way — the binary is
+# already installed; a dynamic-linker failure will surface its own message.
+echo "Installed lumitide → $INSTALL_DIR/lumitide"
+if ! "$INSTALL_DIR/lumitide" --help >/dev/null 2>&1; then
+	echo "warning: '$INSTALL_DIR/lumitide --help' exited nonzero — check shared library dependencies" >&2
+fi
+
+case ":$PATH:" in
+	*":$INSTALL_DIR:"*) ;;
+	*)
+		echo ""
+		echo "$INSTALL_DIR is not on your PATH. Add it with:"
+		case "${SHELL:-}" in
+			*/zsh)  echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc && exec zsh" ;;
+			*/bash) echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.bashrc && exec bash" ;;
+			*)      echo "  export PATH=\"$INSTALL_DIR:\$PATH\"" ;;
+		esac
+		;;
+esac
+
+echo ""
+echo "Run 'lumitide' to start."


### PR DESCRIPTION
## Summary

- **`install.sh`** — Linux/macOS bash installer. Detects OS/arch, downloads the matching `lumitide-linux` / `lumitide-macos` release asset via `curl` (or `wget` fallback), atomically installs to `$LUMITIDE_PREFIX` (default `~/.local/bin`), and prints a PATH hint if the install dir isn't already on `$PATH`. Supports `--version vX.Y.Z` to pin a release.
- **`install.ps1`** — Windows PowerShell 7+ installer. Downloads the portable `lumitide-windows.exe` into `%LOCALAPPDATA%\Programs\lumitide`, updates the User `PATH` (no UAC prompt), and creates a Start Menu shortcut. Supports `-Version`, `-Prefix`, `-NoShortcut`, `-VerboseLog`.
- **README** — new "Quick install (one-liner)" subsection above the existing Download section, with `curl | bash` and `irm | iex` one-liners.

Once merged, the published one-liners will be:
```sh
curl -fsSL https://raw.githubusercontent.com/BreakLime/lumitide/main/install.sh | bash
```
```powershell
irm https://raw.githubusercontent.com/BreakLime/lumitide/main/install.ps1 | iex
```

## Test this branch before merge

Runs straight from the fork — no checkout needed. Note the `refs/heads/` prefix: `raw.githubusercontent.com` can't disambiguate a branch name containing a `/` without it.

**Linux / macOS:**
```sh
curl -fsSL https://raw.githubusercontent.com/BrettKinny/lumitide/refs/heads/feat/install-script/install.sh | bash
```

**Windows (PowerShell 7+):**
```powershell
irm https://raw.githubusercontent.com/BrettKinny/lumitide/refs/heads/feat/install-script/install.ps1 | iex
```

Confirmed working on Arch Linux (Omarchy). Windows smoke test pending — that's what's gating this PR out of draft.

## Design notes

- **Windows does not depend on `lumitide-installer.exe`.** `install.ps1` fetches the portable exe and handles install dir / PATH / Start Menu itself, entirely in PowerShell. The Inno installer continues to be built and published — this script just doesn't touch it.
- **Refuses to run alongside a wizard install.** `install.ps1` path-checks `Program Files\Lumitide`, `Program Files (x86)\Lumitide`, and `%LOCALAPPDATA%\Programs\Lumitide` for an existing `lumitide.exe` from the Inno installer and aborts with instructions to uninstall via Settings > Apps first. Avoids the footgun of two `lumitide.exe` on PATH at different scopes.
- **No rc-file editing on Unix.** `install.sh` prints a PATH hint if `~/.local/bin` isn't on `$PATH` but never edits `.bashrc` / `.zshrc` — lumitide is just a binary on PATH, no shell function wrappers needed.
- **Self-check uses `--help`, not `--version`.** Lumitide's clap config has no `--version` flag; `--help` exits 0 cleanly and is still a useful smoke test that the binary's shared libs loaded.

## Deferred / out of scope

- **Whether to drop `lumitide-installer.exe` + `installer/lumitide.iss` entirely** in a follow-up is not decided here. Both paths currently coexist.
- **SmartScreen / Authenticode signing status** of `lumitide-windows.exe` has not been verified. If the published binary is unsigned, first-run users of `irm | iex` will hit a "Windows protected your PC" dialog. Worth checking / planning signing as a follow-up.
- **ARM Linux / Apple Silicon native binaries** — not published today. `install.sh` routes Apple Silicon to the x86_64 macOS asset (runs under Rosetta 2) with a stderr note, and refuses non-x86_64 Linux with a "build from source" hint.

## Test plan

- [x] `bash -n install.sh` — passes
- [x] Happy path on Arch Linux — downloads latest, installs to `~/.local/bin/lumitide`, `lumitide --help` runs cleanly
- [x] Idempotent re-run — back-to-back runs succeed, overwrites atomically
- [x] `--version v1.0.8` pin — both `--version v1.0.8` and `--version=v1.0.8` forms work
- [x] Arch refusal — fakes `uname` → aborts with build-from-source hint, no 404
- [x] No downloader — `env -i PATH=<minimal>` without curl/wget → clean `error: need curl or wget on PATH`
- [x] Real `curl | bash` from the fork branch on Omarchy (Arch) — works end-to-end
- [x] `shellcheck install.sh` — run on omarchy dev machine
- [x] `pwsh` parse check on `install.ps1` —run on win11 machine
- [x] **Windows 11 smoke test** — fresh install, PATH propagation in a new terminal, shortcut creation, re-run while `lumitide.exe` is in use, Inno-install refusal path - not run