### PR TITLE
Make auth URL clickable in terminal

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -150,7 +150,7 @@ fn device_auth_flow() -> Result<Session> {
     let device: DeviceResp = resp.json()?;
 
     println!("\nTo log in to Tidal, visit:");
-    println!("  {}", device.verification_uri);
+    println!("  \x1B]8;;{}\x1B\\{}\x1B]8;;\x1B\\", device.verification_uri, device.verification_uri);
     println!("And enter code: {}", device.user_code);
     println!("\nWaiting for authorisation...");
 


### PR DESCRIPTION
## Summary
- Wraps the device-auth verification URL in an OSC 8 hyperlink escape sequence so it's clickable in supported terminals (kitty, alacritty, iTerm2, Windows Terminal, etc.)

## Test plan
- [ ] Delete `~/.config/lumitide/session.json` and run `lumitide` to trigger the auth flow
- [ ] Verify the URL is clickable (ctrl+click or cmd+click depending on terminal)
- [ ] Verify terminals without OSC 8 support still display the URL as plain text (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)