### PR TITLE
Auto-advance to next track in liked tracks

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -403,11 +403,12 @@ fn liked_tracks(client: &mut TidalClient, debug: bool) -> Result<()> {
     let mut items: Vec<crate::api::TrackInfo> = Vec::new();
     let mut labels: Vec<String> = Vec::new();
     let cfg = config::load();
+    let volume = Arc::new(Mutex::new(cfg.volume));
 
     let format_track = |t: &crate::api::TrackInfo| format!("{} — {}", t.title, t.artist_name);
 
     loop {
-        let Some(idx) = fuzzy_select(
+        let Some(start_idx) = fuzzy_select(
             "Search tracks",
             "You don't have any liked tracks yet.\n\nLike some tracks in the Tidal app and they will appear here.\n\nPress any key to go back.",
             &mut items, &mut labels, &rx, &format_track,
@@ -415,14 +416,38 @@ fn liked_tracks(client: &mut TidalClient, debug: bool) -> Result<()> {
             break;
         };
 
-        let track = &items[idx];
-        let saved = is_saved(&cfg.output_dir, &track.artist_name, &track.title);
-        let result = preview::run(client, track.id, debug, None, None, saved, None)?;
-        if result.starts_with("radio:") {
-            if let Ok(id) = result["radio:".len()..].parse::<u64>() {
-                radio::run(client, id, debug)?;
+        let mut idx = start_idx;
+        let mut direction: Option<&str> = None;
+        loop {
+            let track = &items[idx];
+            let saved = is_saved(&cfg.output_dir, &track.artist_name, &track.title);
+            let label = format!("{} / {}", idx + 1, items.len());
+            let result = preview::run(
+                client,
+                track.id,
+                debug,
+                Some(label),
+                Some(volume.clone()),
+                saved,
+                direction,
+            )?;
+            match result.as_str() {
+                "prev" => {
+                    idx = (idx + items.len() - 1) % items.len();
+                    direction = Some("prev");
+                }
+                "quit" => break,
+                r if r.starts_with("radio:") => {
+                    if let Ok(id) = r["radio:".len()..].parse::<u64>() {
+                        radio::run(client, id, debug)?;
+                    }
+                    return Ok(());
+                }
+                _ => {
+                    idx = (idx + 1) % items.len();
+                    direction = Some("next");
+                }
             }
-            break;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a small UX bug reported against the library browser: after a liked track finishes playing, it returned to the fuzzy-search list instead of auto-advancing to the next track.

Wraps the single `preview::run` call in `liked_tracks()` in a play-loop that advances `idx` on normal completion and handles `prev` / `quit` / `radio:` — matching the pattern already used by `mix.rs`, `playlist.rs`, and `saved_albums()` in the same file. Also threads the `N / total` label and a shared volume handle through so the playback UI is consistent with other surfaces.

## Stacking note

This branch is stacked on [`feat/browse-library`](https://github.com/BrettKinny/lumitide/tree/feat/browse-library) (which introduces `src/library.rs`). That branch is not yet PR'd, so GitHub shows **two commits** in the diff here:

- `d6434ea` Add library browser with fuzzy search and background streaming *(from `feat/browse-library` — not for review in this PR)*
- `bdf8d39` Auto-advance to next track when a liked track finishes *(the actual fix)*

Happy to split into a separate PR for `feat/browse-library` first if you'd prefer — just let me know.

## Test plan

- [x] Build clean (`cargo build`)
- [x] Tests pass (`cargo test`)
- [x] Manual: opened Library → Liked tracks, played a track, confirmed it auto-advances to the next instead of bouncing to the search list
- [ ] Verify `prev` / `quit` / radio shortcut still behave correctly
- [ ] Verify track-position label (`N / total`) and persistent volume work like other surfaces