### PR TITLE
feat: like/unlike the current track with the `l` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stream audio from your Tidal account directly in the terminal, with album art, a
 
 ![Lumitide demo](assets/demo.gif)
 
-**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`L` like &nbsp;`r` radio &nbsp;`?` controls &nbsp;`q/Esc` back
+**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`l` like &nbsp;`r` radio &nbsp;`?` controls &nbsp;`q/Esc` back
 
 **Lists:** `↑↓` / `jk` navigate &nbsp;`Enter` play &nbsp;`d` queue for download &nbsp;`Esc/q` back
 
@@ -173,7 +173,7 @@ lumitide config                        # open the config file in your editor
 | `↑` / `+` | Volume up |
 | `↓` / `-` | Volume down |
 | `d` | Download current track to disk |
-| `L` | Like / unlike current track (Tidal favorite) |
+| `l` | Like / unlike current track (Tidal favorite) |
 | `r` | Start radio from current track |
 | `?` | Toggle controls overlay |
 | `q` / `Esc` | Go back |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stream audio from your Tidal account directly in the terminal, with album art, a
 
 ![Lumitide demo](assets/demo.gif)
 
-**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`r` radio &nbsp;`?` controls &nbsp;`q/Esc` back
+**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`L` like &nbsp;`r` radio &nbsp;`?` controls &nbsp;`q/Esc` back
 
 **Lists:** `↑↓` / `jk` navigate &nbsp;`Enter` play &nbsp;`d` queue for download &nbsp;`Esc/q` back
 
@@ -173,6 +173,7 @@ lumitide config                        # open the config file in your editor
 | `↑` / `+` | Volume up |
 | `↓` / `-` | Volume down |
 | `d` | Download current track to disk |
+| `L` | Like / unlike current track (Tidal favorite) |
 | `r` | Start radio from current track |
 | `?` | Toggle controls overlay |
 | `q` / `Esc` | Go back |

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::{anyhow, Result};
 use base64::Engine;
 use serde::Deserialize;
@@ -5,6 +7,10 @@ use serde::Deserialize;
 use crate::auth::Session;
 
 const API_BASE: &str = "https://api.tidal.com/v1";
+
+// Cap favourite (like/unlike) requests so a stalled connection can't leave the
+// toggle's in-flight guard stuck and lock the user out of re-toggling.
+const FAVORITES_TIMEOUT: Duration = Duration::from_secs(15);
 
 // ─── Public data types ────────────────────────────────────────────────────────
 
@@ -175,12 +181,10 @@ impl TidalClient {
         form: &[(&str, &str)],
     ) -> Result<reqwest::blocking::Response> {
         let url = format!("{}/{}", API_BASE, path);
-        let mut req = self.client.post(&url)
-            .header("Authorization", self.session.auth_header());
-        for &(k, v) in params {
-            req = req.query(&[(k, v)]);
-        }
-        let resp = req.form(form).send()?;
+        let req = self.client.post(&url)
+            .header("Authorization", self.session.auth_header())
+            .query(params);
+        let resp = req.form(form).timeout(FAVORITES_TIMEOUT).send()?;
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().unwrap_or_default();
@@ -191,12 +195,10 @@ impl TidalClient {
 
     fn delete(&self, path: &str, params: &[(&str, &str)]) -> Result<reqwest::blocking::Response> {
         let url = format!("{}/{}", API_BASE, path);
-        let mut req = self.client.delete(&url)
-            .header("Authorization", self.session.auth_header());
-        for &(k, v) in params {
-            req = req.query(&[(k, v)]);
-        }
-        let resp = req.send()?;
+        let req = self.client.delete(&url)
+            .header("Authorization", self.session.auth_header())
+            .query(params);
+        let resp = req.timeout(FAVORITES_TIMEOUT).send()?;
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().unwrap_or_default();

--- a/src/api.rs
+++ b/src/api.rs
@@ -137,6 +137,7 @@ impl From<RawTrack> for TrackInfo {
 
 // ─── Client ───────────────────────────────────────────────────────────────────
 
+#[derive(Clone)]
 pub struct TidalClient {
     pub session: Session,
     client: reqwest::blocking::Client,
@@ -165,6 +166,68 @@ impl TidalClient {
             return Err(anyhow!("API error {} on {}: {}", status, path, body));
         }
         Ok(resp)
+    }
+
+    fn post_form(
+        &self,
+        path: &str,
+        params: &[(&str, &str)],
+        form: &[(&str, &str)],
+    ) -> Result<reqwest::blocking::Response> {
+        let url = format!("{}/{}", API_BASE, path);
+        let mut req = self.client.post(&url)
+            .header("Authorization", self.session.auth_header());
+        for &(k, v) in params {
+            req = req.query(&[(k, v)]);
+        }
+        let resp = req.form(form).send()?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().unwrap_or_default();
+            return Err(anyhow!("API error {} on {}: {}", status, path, body));
+        }
+        Ok(resp)
+    }
+
+    fn delete(&self, path: &str, params: &[(&str, &str)]) -> Result<reqwest::blocking::Response> {
+        let url = format!("{}/{}", API_BASE, path);
+        let mut req = self.client.delete(&url)
+            .header("Authorization", self.session.auth_header());
+        for &(k, v) in params {
+            req = req.query(&[(k, v)]);
+        }
+        let resp = req.send()?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().unwrap_or_default();
+            return Err(anyhow!("API error {} on {}: {}", status, path, body));
+        }
+        Ok(resp)
+    }
+
+    // ── Favorites (like / unlike) ──────────────────────────────────────────────
+
+    /// Add a track to the user's favorites — the same action as tapping the
+    /// heart button in the Tidal app. POSTs to the favorites collection the
+    /// `liked_tracks_page` reader pulls from. Idempotent: re-liking an already
+    /// favorited track succeeds. Requires the `w_usr` scope (already granted).
+    pub fn like_track(&self, track_id: u64) -> Result<()> {
+        let track_id_s = track_id.to_string();
+        self.post_form(
+            &format!("users/{}/favorites/tracks", self.session.user_id),
+            &[("countryCode", &self.session.country_code)],
+            &[("trackIds", &track_id_s), ("onArtifactNotFound", "FAIL")],
+        )?;
+        Ok(())
+    }
+
+    /// Remove a track from the user's favorites ("unlike").
+    pub fn unlike_track(&self, track_id: u64) -> Result<()> {
+        self.delete(
+            &format!("users/{}/favorites/tracks/{}", self.session.user_id, track_id),
+            &[("countryCode", &self.session.country_code)],
+        )?;
+        Ok(())
     }
 
     // ── Track ────────────────────────────────────────────────────────────────

--- a/src/library.rs
+++ b/src/library.rs
@@ -501,7 +501,8 @@ fn liked_tracks(client: &mut TidalClient, debug: bool) -> Result<()> {
             let track = &items[filtered[pos]];
             let saved = is_saved(&cfg.output_path(), &track.artist_name, &track.title);
             let label = format!("{} / {}", pos + 1, filtered.len());
-            let result = preview::run(client, track.id, debug, Some(label), Some(volume.clone()), saved, direction)?;
+            // These come from the liked-tracks list, so the heart starts filled.
+            let result = preview::run(client, track.id, debug, Some(label), Some(volume.clone()), saved, true, direction)?;
             match result.as_str() {
                 "quit" => break, // back to fuzzy select
                 "prev" => {
@@ -575,6 +576,7 @@ fn saved_albums(client: &mut TidalClient, debug: bool) -> Result<()> {
                 Some(label),
                 Some(volume.clone()),
                 saved,
+                false,
                 direction,
             )?;
 
@@ -662,7 +664,7 @@ fn followed_artists(client: &mut TidalClient, debug: bool) -> Result<()> {
                 let track = &track_items[filtered[pos]];
                 let saved = is_saved(&cfg.output_path(), &track.artist_name, &track.title);
                 let label = format!("{} / {}", pos + 1, filtered.len());
-                let result = preview::run(client, track.id, debug, Some(label), Some(volume.clone()), saved, direction)?;
+                let result = preview::run(client, track.id, debug, Some(label), Some(volume.clone()), saved, false, direction)?;
                 match result.as_str() {
                     "quit" => break, // back to fuzzy select
                     "prev" => {

--- a/src/mix.rs
+++ b/src/mix.rs
@@ -139,7 +139,7 @@ pub fn run(client: &mut TidalClient, debug: bool) -> Result<()> {
                     let saved = is_saved(&cfg.output_path(), &track.artist_name, &track.title);
                     let label = format!("{} / {}", play_idx + 1, tracks.len());
 
-                    let result = preview::run(client, track.id, debug, Some(label), Some(volume.clone()), saved, direction)?;
+                    let result = preview::run(client, track.id, debug, Some(label), Some(volume.clone()), saved, false, direction)?;
 
                     match result.as_str() {
                         "prev" => { play_idx = (play_idx + tracks.len() - 1) % tracks.len(); direction = Some("prev"); }

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -88,7 +88,7 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
         let hint_text = if state.is_local {
             "← prev  Spc pause  → next  ↑↓ vol  q/Esc quit"
         } else {
-            "← prev  Spc pause  → next  ↑↓ vol  d download  L like  r radio  q/Esc quit"
+            "← prev  Spc pause  → next  ↑↓ vol  d download  l like  r radio  q/Esc quit"
         };
         let controls = Title::from(Line::styled(hint_text, dim))
             .alignment(Alignment::Center);

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -27,6 +27,8 @@ pub struct PanelState<'a> {
     pub is_local: bool,
     /// Whether the current track is a Tidal favorite (shows a heart by the title).
     pub liked: bool,
+    /// Set briefly after a like/unlike request fails, to flag it didn't take.
+    pub like_failed: bool,
     pub show_controls: bool,
     pub show_controls_hint: bool,
     pub queue_status: Option<String>,
@@ -133,6 +135,9 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
     ];
     if state.liked {
         title_line.push(Span::styled("  ♥", title_style));
+    }
+    if state.like_failed {
+        title_line.push(Span::styled("  ✗ like failed", dim));
     }
     right.push(Line::from(title_line));
     right.push(Line::from(Span::styled(state.artist_name.to_string(), dim)));

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -25,6 +25,8 @@ pub struct PanelState<'a> {
     /// Pre-rendered spectrum or download-progress lines (BAR_HEIGHT rows).
     pub vis_lines: &'a [Line<'static>],
     pub is_local: bool,
+    /// Whether the current track is a Tidal favorite (shows a heart by the title).
+    pub liked: bool,
     pub show_controls: bool,
     pub show_controls_hint: bool,
     pub queue_status: Option<String>,
@@ -84,7 +86,7 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
         let hint_text = if state.is_local {
             "← prev  Spc pause  → next  ↑↓ vol  q/Esc quit"
         } else {
-            "← prev  Spc pause  → next  ↑↓ vol  d download  r radio  q/Esc quit"
+            "← prev  Spc pause  → next  ↑↓ vol  d download  L like  r radio  q/Esc quit"
         };
         let controls = Title::from(Line::styled(hint_text, dim))
             .alignment(Alignment::Center);
@@ -126,7 +128,13 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
     let mut right: Vec<Line<'static>> = Vec::new();
 
     right.push(Line::raw(""));
-    right.push(Line::from(Span::styled(state.track_name.to_string(), title_style)));
+    let mut title_line: Vec<Span<'static>> = vec![
+        Span::styled(state.track_name.to_string(), title_style),
+    ];
+    if state.liked {
+        title_line.push(Span::styled("  ♥", title_style));
+    }
+    right.push(Line::from(title_line));
     right.push(Line::from(Span::styled(state.artist_name.to_string(), dim)));
     right.push(Line::from(Span::styled(state.album_name.to_string(), dim)));
     if let Some(label) = state.track_label {

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -142,7 +142,7 @@ pub fn run(client: &mut TidalClient, debug: bool) -> Result<()> {
                     let saved = is_saved(&cfg.output_path(), &track.artist_name, &track.title);
                     let label = format!("{} / {}", play_idx + 1, tracks.len());
 
-                    let result = preview::run(client, track.id, debug, Some(label), Some(volume.clone()), saved, direction)?;
+                    let result = preview::run(client, track.id, debug, Some(label), Some(volume.clone()), saved, false, direction)?;
 
                     match result.as_str() {
                         "prev" => { play_idx = (play_idx + tracks.len() - 1) % tracks.len(); direction = Some("prev"); }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -533,6 +533,7 @@ pub fn run(
         volume,
         false,
         already_saved,
+        Some(client.clone()),
     )?;
 
     download_done.store(true, Ordering::Relaxed); // signal dl thread to stop
@@ -569,6 +570,7 @@ pub fn run_local(
         volume,
         true,
         false,
+        None, // local files can't be liked on Tidal
     )
 }
 
@@ -647,6 +649,7 @@ fn play(
     volume: Arc<Mutex<f32>>,
     is_local: bool,
     already_saved: bool,
+    like_client: Option<TidalClient>,
 ) -> Result<String> {
     let cfg = config::load();
 
@@ -707,6 +710,11 @@ fn play(
         if already_saved { "✓ Saved".to_string() } else { String::new() }
     ));
     let dl_flash_until: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+
+    // ── Like state ────────────────────────────────────────────────────────────
+    // Local toggle: 'L' adds the track to Tidal favorites, 'L' again removes it.
+    // Updated optimistically and reverted if the network request fails.
+    let liked = Arc::new(AtomicBool::new(false));
 
     let drop_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
     let beat_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
@@ -973,6 +981,7 @@ fn play(
             bar_color,
             vis_lines: &vis,
             is_local,
+            liked: liked.load(Ordering::Relaxed),
             show_controls,
             show_controls_hint: cfg.show_controls_hint,
             queue_status,
@@ -1028,6 +1037,28 @@ fn play(
                         }
                         KeyCode::Char('?') => {
                             show_controls = !show_controls;
+                        }
+                        KeyCode::Char('l') | KeyCode::Char('L') => {
+                            // Toggle the favorite on Tidal. No-op for local files
+                            // (no client). Network call runs off the UI thread so
+                            // the visualizer keeps animating; state is reverted if
+                            // the request fails.
+                            if let Some(c) = like_client.clone() {
+                                let now_liked = !liked.load(Ordering::Relaxed);
+                                liked.store(now_liked, Ordering::Relaxed); // optimistic
+                                let liked_flag = liked.clone();
+                                let tid = track.id;
+                                thread::spawn(move || {
+                                    let res = if now_liked {
+                                        c.like_track(tid)
+                                    } else {
+                                        c.unlike_track(tid)
+                                    };
+                                    if res.is_err() {
+                                        liked_flag.store(!now_liked, Ordering::Relaxed);
+                                    }
+                                });
+                            }
                         }
                         KeyCode::Char('d') | KeyCode::Char('D') => {
                             if already_saved || is_local {

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -449,6 +449,7 @@ pub fn run(
     track_label: Option<String>,
     shared_volume: Option<Arc<Mutex<f32>>>,
     already_saved: bool,
+    already_liked: bool,
     direction: Option<&str>,
 ) -> Result<String> {
     // ── Terminal up before API calls so the transition stays on screen ────────
@@ -533,6 +534,7 @@ pub fn run(
         volume,
         false,
         already_saved,
+        already_liked,
         Some(client.clone()),
     )?;
 
@@ -570,6 +572,7 @@ pub fn run_local(
         volume,
         true,
         false,
+        false, // already_liked — not applicable to local files
         None, // local files can't be liked on Tidal
     )
 }
@@ -649,6 +652,7 @@ fn play(
     volume: Arc<Mutex<f32>>,
     is_local: bool,
     already_saved: bool,
+    already_liked: bool,
     like_client: Option<TidalClient>,
 ) -> Result<String> {
     let cfg = config::load();
@@ -712,9 +716,16 @@ fn play(
     let dl_flash_until: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
 
     // ── Like state ────────────────────────────────────────────────────────────
-    // Local toggle: 'L' adds the track to Tidal favorites, 'L' again removes it.
-    // Updated optimistically and reverted if the network request fails.
-    let liked = Arc::new(AtomicBool::new(false));
+    // 'L' toggles the track in the user's Tidal favorites. Seeded from
+    // `already_liked` so the heart reflects reality on entry (e.g. when browsing
+    // the liked-tracks list) rather than always starting empty — otherwise the
+    // first press on an already-favorited track would silently arm a destructive
+    // unlike. Updated optimistically and reverted if the network request fails.
+    // `like_inflight` allows only one toggle at a time: rapid presses are dropped
+    // until it resolves, so a like/unlike pair can't complete out of order and
+    // leave the server disagreeing with the heart.
+    let liked = Arc::new(AtomicBool::new(already_liked));
+    let like_inflight = Arc::new(AtomicBool::new(false));
 
     let drop_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
     let beat_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
@@ -1044,20 +1055,27 @@ fn play(
                             // the visualizer keeps animating; state is reverted if
                             // the request fails.
                             if let Some(c) = like_client.clone() {
-                                let now_liked = !liked.load(Ordering::Relaxed);
-                                liked.store(now_liked, Ordering::Relaxed); // optimistic
-                                let liked_flag = liked.clone();
-                                let tid = track.id;
-                                thread::spawn(move || {
-                                    let res = if now_liked {
-                                        c.like_track(tid)
-                                    } else {
-                                        c.unlike_track(tid)
-                                    };
-                                    if res.is_err() {
-                                        liked_flag.store(!now_liked, Ordering::Relaxed);
-                                    }
-                                });
+                                // swap() returns the prior value; only proceed if no
+                                // toggle was already in flight, so overlapping
+                                // requests can't race to opposite outcomes.
+                                if !like_inflight.swap(true, Ordering::Relaxed) {
+                                    let now_liked = !liked.load(Ordering::Relaxed);
+                                    liked.store(now_liked, Ordering::Relaxed); // optimistic
+                                    let liked_flag = liked.clone();
+                                    let inflight_flag = like_inflight.clone();
+                                    let tid = track.id;
+                                    thread::spawn(move || {
+                                        let res = if now_liked {
+                                            c.like_track(tid)
+                                        } else {
+                                            c.unlike_track(tid)
+                                        };
+                                        if res.is_err() {
+                                            liked_flag.store(!now_liked, Ordering::Relaxed);
+                                        }
+                                        inflight_flag.store(false, Ordering::Relaxed);
+                                    });
+                                }
                             }
                         }
                         KeyCode::Char('d') | KeyCode::Char('D') => {

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -723,9 +723,12 @@ fn play(
     // unlike. Updated optimistically and reverted if the network request fails.
     // `like_inflight` allows only one toggle at a time: rapid presses are dropped
     // until it resolves, so a like/unlike pair can't complete out of order and
-    // leave the server disagreeing with the heart.
+    // leave the server disagreeing with the heart. On failure the optimistic
+    // flip is reverted *and* `like_flash` is set so the UI briefly shows the
+    // toggle didn't take, rather than silently snapping back.
     let liked = Arc::new(AtomicBool::new(already_liked));
     let like_inflight = Arc::new(AtomicBool::new(false));
+    let like_flash: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
 
     let drop_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
     let beat_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
@@ -969,6 +972,16 @@ fn play(
         let dl_b = dl_bytes.load(Ordering::Relaxed);
         let dl_t = dl_total.load(Ordering::Relaxed);
 
+        // Like-failure flash: active until its deadline, then auto-clears.
+        let like_failed = {
+            let mut f = like_flash.lock().unwrap_or_else(|e| e.into_inner());
+            match *f {
+                Some(deadline) if Instant::now() < deadline => true,
+                Some(_) => { *f = None; false }
+                None => false,
+            }
+        };
+
         // Build visualisation lines
         let spec = spec_buf.lock().unwrap_or_else(|e| e.into_inner()).clone();
         let vis = panel::build_vis_lines(
@@ -993,6 +1006,7 @@ fn play(
             vis_lines: &vis,
             is_local,
             liked: liked.load(Ordering::Relaxed),
+            like_failed,
             show_controls,
             show_controls_hint: cfg.show_controls_hint,
             queue_status,
@@ -1063,6 +1077,7 @@ fn play(
                                     liked.store(now_liked, Ordering::Relaxed); // optimistic
                                     let liked_flag = liked.clone();
                                     let inflight_flag = like_inflight.clone();
+                                    let flash_flag = like_flash.clone();
                                     let tid = track.id;
                                     thread::spawn(move || {
                                         let res = if now_liked {
@@ -1072,6 +1087,8 @@ fn play(
                                         };
                                         if res.is_err() {
                                             liked_flag.store(!now_liked, Ordering::Relaxed);
+                                            *flash_flag.lock().unwrap_or_else(|e| e.into_inner()) =
+                                                Some(Instant::now() + Duration::from_secs(2));
                                         }
                                         inflight_flag.store(false, Ordering::Relaxed);
                                     });

--- a/src/radio.rs
+++ b/src/radio.rs
@@ -30,6 +30,7 @@ pub fn run(client: &mut TidalClient, seed_track_id: u64, debug: bool) -> Result<
             Some(label),
             Some(volume.clone()),
             saved,
+            false,
             direction,
         )?;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -148,7 +148,7 @@ pub fn run(client: &mut TidalClient, query: &str, limit: u32, by_artist: bool) -
             Action::Play(idx) => {
                 let track = &tracks[idx];
                 let saved = is_saved(&cfg.output_path(), &track.artist_name, &track.title);
-                let result = preview::run(client, track.id, false, None, None, saved, None)?;
+                let result = preview::run(client, track.id, false, None, None, saved, false, None)?;
                 if result.starts_with("radio:") {
                     if let Ok(id) = result["radio:".len()..].parse::<u64>() {
                         radio::run(client, id, false)?;


### PR DESCRIPTION
## Summary

Adds favorite (like) support to the player: press **`l`** while a track is playing to add it to / remove it from your Tidal favorites — the same collection the liked-tracks library view reads from. A heart shows beside the title when the current track is a favorite.

![like heart on a liked track](https://raw.githubusercontent.com/BrettKinny/lumitide/pr-screenshots/assets/pr/likes-heart.png)

## What it does

- **`l`** toggles the current track's favorite status (handler accepts `l`/`L`).
- Heart (`♥`) beside the title reflects favorite state.
- The network call runs **off the UI thread**, so the visualizer keeps animating; the heart updates optimistically and **reverts if the request fails**, with a brief `✗ like failed` flash.
- Local files aren't likeable (no-op).

## Implementation notes

- `api.rs`: `like_track` / `unlike_track` on `TidalClient`, backed by `post_form` / `delete` helpers that POST/DELETE the `users/{id}/favorites/tracks` collection (legacy v1 API, same path the liked-tracks reader uses). The existing session already holds the `w_usr` scope, so no re-auth. `TidalClient` derives `Clone` so the player loop can hand a copy to background threads.
- `preview.rs`: heart state is **seeded from context** — the liked-tracks browser passes `already_liked = true`, so the heart is correct on entry rather than always starting empty (otherwise a first press on an already-favorited track would silently arm a destructive unlike). A single in-flight guard prevents rapid presses from racing to opposite outcomes.
- `panel.rs`: heart indicator + `l like` in the controls overlay.

Verified end-to-end against a live account: toggling persists in the Tidal app.

---

> **Heads-up for maintainers:** this shares `play()`'s plumbing with my track/artist-info popups PR (the `Option<TidalClient>` passed into `play()` for off-thread fetches). They're independent features; whichever merges second needs a trivial unification (a single client handle serves both). Happy to rebase whichever you take second.
