### PR TITLE
feat: track & artist info popups (`t` / `a`) with credits and biography

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stream audio from your Tidal account directly in the terminal, with album art, a
 
 ![Lumitide demo](assets/demo.gif)
 
-**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`r` radio &nbsp;`i` info &nbsp;`a` artist &nbsp;`?` controls &nbsp;`q/Esc` back
+**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`r` radio &nbsp;`t` info &nbsp;`a` artist &nbsp;`?` controls &nbsp;`q/Esc` back
 
 **Lists:** `↑↓` / `jk` navigate &nbsp;`Enter` play &nbsp;`d` queue for download &nbsp;`Esc/q` back
 
@@ -174,7 +174,7 @@ lumitide config                        # open the config file in your editor
 | `↓` / `-` | Volume down |
 | `d` | Download current track to disk |
 | `r` | Start radio from current track |
-| `i` | Toggle track info (year, quality, ISRC, credits…) |
+| `t` | Toggle track info (year, quality, ISRC, credits…) |
 | `a` | Toggle artist info (picture + biography) |
 | `?` | Toggle controls overlay |
 | `q` / `Esc` | Close popup, else quit |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stream audio from your Tidal account directly in the terminal, with album art, a
 
 ![Lumitide demo](assets/demo.gif)
 
-**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`r` radio &nbsp;`?` controls &nbsp;`q/Esc` back
+**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`r` radio &nbsp;`i` info &nbsp;`a` artist &nbsp;`?` controls &nbsp;`q/Esc` back
 
 **Lists:** `↑↓` / `jk` navigate &nbsp;`Enter` play &nbsp;`d` queue for download &nbsp;`Esc/q` back
 
@@ -174,8 +174,10 @@ lumitide config                        # open the config file in your editor
 | `↓` / `-` | Volume down |
 | `d` | Download current track to disk |
 | `r` | Start radio from current track |
+| `i` | Toggle track info (year, quality, ISRC, credits…) |
+| `a` | Toggle artist info (picture + biography) |
 | `?` | Toggle controls overlay |
-| `q` / `Esc` | Go back |
+| `q` / `Esc` | Close popup, else quit |
 
 ### In list views (library, search, mixes, playlists)
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -623,8 +623,10 @@ impl TidalClient {
         })
     }
 
-    /// Fetch an artist biography. Returns `None` when no bio is available
-    /// (Tidal answers 404 for artists without an editorial bio).
+    /// Fetch an artist biography. Returns `None` when no bio is available —
+    /// Tidal answers 404 for artists without an editorial bio, but for
+    /// robustness *any* request error is treated as "no bio" (the bio is purely
+    /// informational, so a transient failure shouldn't surface as an error).
     pub fn artist_bio(&self, artist_id: u64) -> Result<Option<String>> {
         #[derive(Deserialize)]
         struct Raw {
@@ -641,7 +643,8 @@ impl TidalClient {
                 let r: Raw = resp.json()?;
                 Ok(r.text.or(r.summary).map(|s| clean_bio(&s)))
             }
-            // No bio for this artist — not a hard error.
+            // No bio for this artist (404), or a transient request error — either
+            // way, not a hard failure; the popup just shows no biography.
             Err(_) => Ok(None),
         }
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -27,6 +27,7 @@ pub struct TrackInfo {
     pub id: u64,
     pub title: String,
     pub artist_name: String,
+    pub artist_id: Option<u64>, // primary artist, for fetching artist details
     pub album_name: String,
     pub album_cover: Option<String>, // UUID like "ab-cd-ef-gh"
     pub album_artist: String,
@@ -37,13 +38,36 @@ pub struct TrackInfo {
     pub volume_num: u32,
     pub isrc: Option<String>,
     pub audio_quality: String, // e.g. "LOSSLESS", "FLAC", "MP3"
-    pub duration: u64,         // seconds; stored for future display
+    pub duration: u64,         // seconds
+    pub version: Option<String>, // e.g. "Remastered", "Radio Edit"
+    pub explicit: bool,
+    pub popularity: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // picture stored for future artist art display
 pub struct ArtistInfo {
     pub id: u64,
     pub name: String,
+    pub picture: Option<String>, // UUID like "ab-cd-ef-gh"
+}
+
+/// A single credit role (e.g. "Producer") with its contributor names.
+#[derive(Debug, Clone)]
+pub struct Credit {
+    pub role: String,
+    pub names: Vec<String>,
+}
+
+/// Extended artist details: picture, popularity and biography.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct ArtistDetail {
+    pub id: u64,
+    pub name: String,
+    pub picture: Option<String>,
+    pub popularity: Option<u32>,
+    pub bio: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -73,6 +97,8 @@ pub struct AlbumInfo {
 struct RawArtist {
     id: u64,
     name: String,
+    #[serde(default)]
+    picture: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -102,6 +128,10 @@ struct RawTrack {
     artists: Option<Vec<RawArtist>>,
     album: RawAlbum,
     copyright: Option<String>,
+    version: Option<String>,
+    #[serde(default)]
+    explicit: bool,
+    popularity: Option<u32>,
 }
 
 impl From<RawTrack> for TrackInfo {
@@ -115,11 +145,16 @@ impl From<RawTrack> for TrackInfo {
             .map(|a| a.name.clone())
             .or_else(|| r.artists.as_ref().and_then(|v| v.first()).map(|a| a.name.clone()))
             .unwrap_or_default();
+        let artist_id = r.artist
+            .as_ref()
+            .map(|a| a.id)
+            .or_else(|| r.artists.as_ref().and_then(|v| v.first()).map(|a| a.id));
         let copyright = r.copyright.or(r.album.copyright);
         TrackInfo {
             id:                  r.id,
             title:               r.title,
             artist_name:         primary_artist.clone(),
+            artist_id,
             album_name:          r.album.title,
             album_cover:         r.album.cover,
             album_artist:        r.album.artist.map(|a| a.name).unwrap_or(primary_artist),
@@ -131,6 +166,9 @@ impl From<RawTrack> for TrackInfo {
             isrc:                r.isrc,
             audio_quality:       r.audio_quality.unwrap_or_else(|| "UNKNOWN".to_string()),
             duration:            r.duration.unwrap_or(0),
+            version:             r.version,
+            explicit:            r.explicit,
+            popularity:          r.popularity,
         }
     }
 }
@@ -282,7 +320,7 @@ impl TidalClient {
         ])?;
         let data: SearchResp = resp.json()?;
         Ok(data.artists.map(|a| a.items.into_iter()
-            .map(|r| ArtistInfo { id: r.id, name: r.name })
+            .map(|r| ArtistInfo { id: r.id, name: r.name, picture: r.picture })
             .collect())
             .unwrap_or_default())
     }
@@ -523,8 +561,89 @@ impl TidalClient {
         )?;
         let data: Resp = resp.json()?;
         let total = data.total.unwrap_or(0);
-        let artists = data.items.into_iter().map(|f| ArtistInfo { id: f.item.id, name: f.item.name }).collect();
+        let artists = data.items.into_iter().map(|f| ArtistInfo { id: f.item.id, name: f.item.name, picture: f.item.picture }).collect();
         Ok((artists, total))
+    }
+
+    // ── Credits & extended metadata ────────────────────────────────────────────
+
+    /// Fetch per-track credits (producers, composers, engineers, …).
+    pub fn track_credits(&self, track_id: u64) -> Result<Vec<Credit>> {
+        #[derive(Deserialize)]
+        struct RawCredit {
+            #[serde(rename = "type")]
+            role: String,
+            #[serde(default)]
+            contributors: Vec<RawContributor>,
+        }
+        #[derive(Deserialize)]
+        struct RawContributor {
+            name: String,
+        }
+
+        let resp = self.get(
+            &format!("tracks/{}/credits", track_id),
+            &[
+                ("countryCode", &self.session.country_code),
+                ("includeContributors", "true"),
+            ],
+        )?;
+        let raw: Vec<RawCredit> = resp.json()?;
+        Ok(raw.into_iter()
+            .map(|c| Credit {
+                role: c.role,
+                names: c.contributors.into_iter().map(|x| x.name).collect(),
+            })
+            .filter(|c| !c.names.is_empty())
+            .collect())
+    }
+
+    /// Fetch extended artist details (picture, popularity) and biography.
+    pub fn artist_detail(&self, artist_id: u64) -> Result<ArtistDetail> {
+        #[derive(Deserialize)]
+        struct Raw {
+            id: u64,
+            name: String,
+            #[serde(default)]
+            picture: Option<String>,
+            #[serde(default)]
+            popularity: Option<u32>,
+        }
+        let resp = self.get(
+            &format!("artists/{}", artist_id),
+            &[("countryCode", &self.session.country_code)],
+        )?;
+        let r: Raw = resp.json()?;
+        Ok(ArtistDetail {
+            id: r.id,
+            name: r.name,
+            picture: r.picture,
+            popularity: r.popularity,
+            bio: self.artist_bio(artist_id).unwrap_or(None),
+        })
+    }
+
+    /// Fetch an artist biography. Returns `None` when no bio is available
+    /// (Tidal answers 404 for artists without an editorial bio).
+    pub fn artist_bio(&self, artist_id: u64) -> Result<Option<String>> {
+        #[derive(Deserialize)]
+        struct Raw {
+            #[serde(default)]
+            text: Option<String>,
+            #[serde(default)]
+            summary: Option<String>,
+        }
+        match self.get(
+            &format!("artists/{}/bio", artist_id),
+            &[("countryCode", &self.session.country_code)],
+        ) {
+            Ok(resp) => {
+                let r: Raw = resp.json()?;
+                Ok(r.text.or(r.summary).map(|s| clean_bio(&s)))
+            }
+            // No bio for this artist — not a hard error.
+            Err(_) => Ok(None),
+        }
     }
 
     // ── Cover image ──────────────────────────────────────────────────────────
@@ -577,6 +696,23 @@ fn decrypt_security_token(key_id: &str) -> Result<EncryptionInfo> {
     key.copy_from_slice(&buf[..16]);
     nonce.copy_from_slice(&buf[16..24]);
     Ok(EncryptionInfo { key, nonce })
+}
+
+/// Strip Tidal's `[wimpLink …]…[/wimpLink]` markup from a biography, keeping
+/// the human-readable link text (e.g. the linked artist/album name).
+fn clean_bio(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("[wimpLink") {
+        out.push_str(&rest[..start]);
+        // Skip past the opening tag's closing ']'
+        match rest[start..].find(']') {
+            Some(close) => rest = &rest[start + close + 1..],
+            None => { rest = ""; break; }
+        }
+    }
+    out.push_str(rest);
+    out.replace("[/wimpLink]", "").trim().to_string()
 }
 
 #[cfg(test)]
@@ -795,5 +931,44 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn artist_id_captured_from_artist_field() {
+        let t = parse(r#"{"id":1,"title":"Song","artist":{"id":77,"name":"Main"},"album":{"id":100,"title":"Album"}}"#);
+        assert_eq!(t.artist_id, Some(77));
+    }
+
+    #[test]
+    fn artist_id_falls_back_to_artists_array() {
+        let t = parse(r#"{"id":1,"title":"Song","artists":[{"id":88,"name":"First"}],"album":{"id":100,"title":"Album"}}"#);
+        assert_eq!(t.artist_id, Some(88));
+    }
+
+    #[test]
+    fn extended_fields_parsed() {
+        let t = parse(r#"{"id":1,"title":"Song","version":"Remastered","explicit":true,"popularity":63,"album":{"id":100,"title":"Album"}}"#);
+        assert_eq!(t.version, Some("Remastered".to_string()));
+        assert!(t.explicit);
+        assert_eq!(t.popularity, Some(63));
+    }
+
+    #[test]
+    fn extended_fields_default_when_absent() {
+        let t = parse(r#"{"id":1,"title":"Song","album":{"id":100,"title":"Album"}}"#);
+        assert!(t.version.is_none());
+        assert!(!t.explicit);
+        assert!(t.popularity.is_none());
+    }
+
+    #[test]
+    fn clean_bio_strips_wimplink_markup() {
+        let raw = r#"Born in 1980, [wimpLink artistId="123"]John Doe[/wimpLink] is a producer."#;
+        assert_eq!(clean_bio(raw), "Born in 1980, John Doe is a producer.");
+    }
+
+    #[test]
+    fn clean_bio_handles_plain_text() {
+        assert_eq!(clean_bio("  Just a normal bio.  "), "Just a normal bio.");
     }
 }

--- a/src/cover.rs
+++ b/src/cover.rs
@@ -27,6 +27,7 @@ const BRAILLE_DOTS: [(usize, usize, u32); 8] = [
 ];
 
 /// Rendered cover: two Text representations + 3-colour palette.
+#[derive(Clone)]
 pub struct CoverArt {
     /// White Braille art (normal/no-colour mode).
     pub mono: Vec<Line<'static>>,

--- a/src/download_queue.rs
+++ b/src/download_queue.rs
@@ -205,6 +205,7 @@ mod tests {
             id,
             title: title.to_string(),
             artist_name: artist.to_string(),
+            artist_id: None,
             album_name: String::new(),
             album_cover: None,
             album_artist: String::new(),
@@ -216,6 +217,9 @@ mod tests {
             isrc: None,
             audio_quality: "LOSSLESS".to_string(),
             duration: 240,
+            version: None,
+            explicit: false,
+            popularity: None,
         }
     }
 

--- a/src/local.rs
+++ b/src/local.rs
@@ -174,6 +174,7 @@ fn fallback_track_info(path: &std::path::Path) -> TrackInfo {
         id: 0,
         title,
         artist_name: "Unknown".to_string(),
+        artist_id: None,
         album_name: String::new(),
         album_cover: None,
         album_artist: String::new(),
@@ -185,6 +186,9 @@ fn fallback_track_info(path: &std::path::Path) -> TrackInfo {
         isrc: None,
         audio_quality: "AUDIO".to_string(),
         duration: 0,
+        version: None,
+        explicit: false,
+        popularity: None,
     }
 }
 
@@ -229,6 +233,7 @@ fn read_local_metadata(path: &std::path::Path) -> (TrackInfo, Option<Vec<u8>>) {
         id: 0,
         title,
         artist_name,
+        artist_id: None,
         album_name,
         album_cover: None,
         album_artist: String::new(),
@@ -240,6 +245,9 @@ fn read_local_metadata(path: &std::path::Path) -> (TrackInfo, Option<Vec<u8>>) {
         isrc: None,
         audio_quality: fmt,
         duration: 0,
+        version: None,
+        explicit: false,
+        popularity: None,
     };
     (track, cover_bytes)
 }

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -2,10 +2,12 @@ use ratatui::{
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{Block, Borders, Paragraph, block::Title},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap, block::Title},
     Frame,
 };
 
+use crate::api::{ArtistDetail, Credit, TrackInfo};
+use crate::cover::CoverArt;
 use crate::spectrum;
 use crate::utils::fmt_time;
 
@@ -82,9 +84,9 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
         let area = Rect::new(x, y, block_w.min(terminal.width), block_h.min(terminal.height));
 
         let hint_text = if state.is_local {
-            "← prev  Spc pause  → next  ↑↓ vol  q/Esc quit"
+            "← prev  Spc pause  → next  ↑↓ vol  i info  a artist  q/Esc quit"
         } else {
-            "← prev  Spc pause  → next  ↑↓ vol  d download  r radio  q/Esc quit"
+            "← prev  Spc pause  → next  ↑↓ vol  d download  r radio  i info  a artist  q/Esc quit"
         };
         let controls = Title::from(Line::styled(hint_text, dim))
             .alignment(Alignment::Center);
@@ -204,5 +206,213 @@ pub fn build_vis_lines(
             spectrum::compute_spectrum(spec_buf, band_edges)
         };
         spectrum::render_spectrum(&normalized, bar_peaks, bar_peak_hold, bar_color)
+    }
+}
+
+// ─── Info popups ───────────────────────────────────────────────────────────────
+
+fn accent_style(accent: Option<(u8, u8, u8)>) -> Style {
+    match accent {
+        Some((r, g, b)) => Style::new().fg(Color::Rgb(r, g, b)),
+        None => Style::new().fg(Color::White),
+    }
+}
+
+/// A "Label  value" line for the info popups.
+fn field(label: &str, value: String, accent: Option<(u8, u8, u8)>) -> Line<'static> {
+    let dim = Style::new().fg(Color::DarkGray);
+    Line::from(vec![
+        Span::styled(format!("{:<11}", label), dim),
+        Span::styled(value, accent_style(accent)),
+    ])
+}
+
+/// Build the body lines for the track-info popup.
+pub fn build_track_info_lines(
+    track: &TrackInfo,
+    credits: Option<&Vec<Credit>>,
+    accent: Option<(u8, u8, u8)>,
+) -> Vec<Line<'static>> {
+    let dim = Style::new().fg(Color::DarkGray);
+    let bold_accent = accent_style(accent).add_modifier(Modifier::BOLD);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Title (+ version + explicit marker)
+    let mut title_spans = vec![Span::styled(track.title.clone(), bold_accent)];
+    if let Some(v) = &track.version {
+        if !v.is_empty() {
+            title_spans.push(Span::styled(format!("  ({v})"), dim));
+        }
+    }
+    if track.explicit {
+        title_spans.push(Span::styled("  [E]", dim));
+    }
+    lines.push(Line::from(title_spans));
+    lines.push(Line::raw(""));
+
+    let artists = if track.artists.is_empty() {
+        track.artist_name.clone()
+    } else {
+        track.artists.join(", ")
+    };
+    lines.push(field("Artists", artists, accent));
+
+    let mut album = track.album_name.clone();
+    if let Some(y) = track.album_release_year {
+        album.push_str(&format!(" ({y})"));
+    }
+    lines.push(field("Album", album, accent));
+    lines.push(field("Track", format!("{} · disc {}", track.track_num, track.volume_num), accent));
+    lines.push(field("Duration", fmt_time(track.duration as f64), accent));
+    lines.push(field("Quality", track.audio_quality.clone(), accent));
+    if let Some(p) = track.popularity {
+        lines.push(field("Popularity", format!("{p}"), accent));
+    }
+    if let Some(isrc) = &track.isrc {
+        lines.push(field("ISRC", isrc.clone(), accent));
+    }
+    if let Some(c) = &track.album_copyright {
+        lines.push(field("©", c.clone(), accent));
+    }
+
+    // ── Credits ──────────────────────────────────────────────────────────────
+    lines.push(Line::raw(""));
+    match credits {
+        None => lines.push(Line::from(Span::styled("Loading credits…", dim))),
+        Some(c) if c.is_empty() => {
+            lines.push(Line::from(Span::styled("No credits available", dim)));
+        }
+        Some(c) => {
+            lines.push(Line::from(Span::styled("Credits", bold_accent)));
+            for credit in c {
+                lines.push(Line::from(vec![
+                    Span::styled(format!("{:<11}", credit.role), dim),
+                    Span::styled(credit.names.join(", "), Style::new().fg(Color::Gray)),
+                ]));
+            }
+        }
+    }
+
+    lines
+}
+
+/// Compute a centred rect for a popup of the given inner content size.
+fn centered(area: Rect, inner_w: u16, inner_h: u16) -> Rect {
+    let box_w = (inner_w + 2).min(area.width);
+    let box_h = (inner_h + 2).min(area.height);
+    let x = area.x + area.width.saturating_sub(box_w) / 2;
+    let y = area.y + area.height.saturating_sub(box_h) / 2;
+    Rect::new(x, y, box_w, box_h)
+}
+
+/// Render a bordered, centred text popup over the current frame.
+pub fn render_info_popup(
+    frame: &mut Frame,
+    title: &str,
+    lines: Vec<Line<'static>>,
+    accent: Option<(u8, u8, u8)>,
+) {
+    let area = frame.area();
+    let content_w = lines.iter().map(|l| l.width()).max().unwrap_or(24) as u16;
+    let inner_w = content_w.clamp(28, area.width.saturating_sub(4).max(28));
+    let inner_h = (lines.len() as u16).min(area.height.saturating_sub(2));
+    let rect = centered(area, inner_w + 1, inner_h); // +1 for left padding
+
+    let border = accent_style(accent);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border)
+        .title(Title::from(Span::styled(
+            format!(" {title} "),
+            border.add_modifier(Modifier::BOLD),
+        )).alignment(Alignment::Center));
+    let inner = block.inner(rect);
+
+    frame.render_widget(Clear, rect);
+    frame.render_widget(block, rect);
+    // Pad one column on the left
+    let text_area = Rect::new(inner.x + 1, inner.y, inner.width.saturating_sub(1), inner.height);
+    frame.render_widget(
+        Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false }),
+        text_area,
+    );
+}
+
+/// Render the artist-info popup: pixelated picture on the left, name +
+/// popularity + biography on the right.
+pub fn render_artist_popup(
+    frame: &mut Frame,
+    fallback_name: &str,
+    detail: Option<&ArtistDetail>,
+    art: Option<&CoverArt>,
+    accent: Option<(u8, u8, u8)>,
+) {
+    let area = frame.area();
+    let dim = Style::new().fg(Color::DarkGray);
+    let bold_accent = accent_style(accent).add_modifier(Modifier::BOLD);
+
+    // ── Right-hand text ────────────────────────────────────────────────────────
+    let name = detail.map(|d| d.name.clone()).unwrap_or_else(|| fallback_name.to_string());
+    let mut info: Vec<Line<'static>> = vec![
+        Line::from(Span::styled(name, bold_accent)),
+    ];
+    if let Some(d) = detail {
+        if let Some(p) = d.popularity {
+            info.push(Line::from(Span::styled(format!("Popularity {p}"), dim)));
+        }
+        info.push(Line::raw(""));
+        match &d.bio {
+            Some(b) if !b.is_empty() => {
+                info.push(Line::from(Span::styled(b.clone(), Style::new().fg(Color::Gray))));
+            }
+            _ => info.push(Line::from(Span::styled("No biography available", dim))),
+        }
+    } else {
+        info.push(Line::raw(""));
+        info.push(Line::from(Span::styled("Loading artist…", dim)));
+    }
+
+    // ── Geometry ───────────────────────────────────────────────────────────────
+    let cover_lines: &[Line<'static>] = art.map(|a| a.color.as_slice()).unwrap_or(&[]);
+    let cover_w = cover_lines.first().map(|l| l.width()).unwrap_or(0) as u16;
+    let pic_col = if cover_w > 0 { cover_w + 2 } else { 0 };
+    let info_col: u16 = 46;
+    let inner_w = pic_col + info_col;
+    let inner_h = (cover_lines.len() as u16).max(16);
+    let rect = centered(area, inner_w, inner_h);
+
+    let border = accent_style(accent);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border)
+        .title(Title::from(Span::styled(
+            " Artist ",
+            border.add_modifier(Modifier::BOLD),
+        )).alignment(Alignment::Center));
+    let inner = block.inner(rect);
+
+    frame.render_widget(Clear, rect);
+    frame.render_widget(block, rect);
+
+    if pic_col > 0 {
+        let cols = Layout::horizontal([
+            Constraint::Length(pic_col),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+        frame.render_widget(
+            Paragraph::new(Text::from(cover_lines.to_vec())),
+            cols[0],
+        );
+        frame.render_widget(
+            Paragraph::new(Text::from(info)).wrap(Wrap { trim: true }),
+            cols[1],
+        );
+    } else {
+        let text_area = Rect::new(inner.x + 1, inner.y, inner.width.saturating_sub(1), inner.height);
+        frame.render_widget(
+            Paragraph::new(Text::from(info)).wrap(Wrap { trim: true }),
+            text_area,
+        );
     }
 }

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -78,9 +78,9 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
     // ── Border + controls (only when show_controls) ───────────────────────────
     let inner = if state.show_controls {
         let hint_text = if state.is_local {
-            "← prev  Spc pause  → next  ↑↓ vol  i info  a artist  q/Esc quit"
+            "← prev  Spc pause  → next  ↑↓ vol  t info  a artist  q/Esc quit"
         } else {
-            "← prev  Spc pause  → next  ↑↓ vol  d download  r radio  i info  a artist  q/Esc quit"
+            "← prev  Spc pause  → next  ↑↓ vol  d download  r radio  t info  a artist  q/Esc quit"
         };
         let hint_line = Line::styled(hint_text, dim);
         // The box must fit the cover+info columns *and* the controls hint in the

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{Block, Borders, Clear, Paragraph, Wrap, block::Title},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap, block::{Position, Title}},
     Frame,
 };
 
@@ -302,6 +302,36 @@ pub fn build_track_info_lines(
 }
 
 /// Compute a centred rect for a popup of the given inner content size.
+/// Count how many rows `lines` occupy once greedily word-wrapped to `width`,
+/// mirroring ratatui's `Wrap` so scroll can be clamped to the real content
+/// height. (ratatui's own `line_count` is behind an unstable feature, so we do
+/// the small amount of arithmetic ourselves.)
+fn wrapped_height(lines: &[Line<'static>], width: u16) -> u16 {
+    let w = width.max(1) as usize;
+    lines.iter().map(|line| {
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        let mut rows: u16 = 1;
+        let mut col = 0usize; // chars used on the current row
+        for word in text.split_whitespace() {
+            let wl = word.chars().count();
+            if col == 0 {
+                col = wl;
+            } else if col + 1 + wl <= w {
+                col += 1 + wl;
+            } else {
+                rows += 1;
+                col = wl;
+            }
+            // A single word longer than the line hard-wraps onto extra rows.
+            while col > w {
+                rows += 1;
+                col -= w;
+            }
+        }
+        rows
+    }).sum()
+}
+
 fn centered(area: Rect, inner_w: u16, inner_h: u16) -> Rect {
     let box_w = (inner_w + 2).min(area.width);
     let box_h = (inner_h + 2).min(area.height);
@@ -310,13 +340,16 @@ fn centered(area: Rect, inner_w: u16, inner_h: u16) -> Rect {
     Rect::new(x, y, box_w, box_h)
 }
 
-/// Render a bordered, centred text popup over the current frame.
+/// Render a bordered, centred text popup over the current frame. `scroll` is the
+/// requested vertical offset; the value actually applied (clamped to the content)
+/// is returned so the caller can keep its stored offset in range.
 pub fn render_info_popup(
     frame: &mut Frame,
     title: &str,
     lines: Vec<Line<'static>>,
     accent: Option<(u8, u8, u8)>,
-) {
+    scroll: u16,
+) -> u16 {
     let area = frame.area();
     let content_w = lines.iter().map(|l| l.width()).max().unwrap_or(24) as u16;
     let inner_w = content_w.clamp(28, area.width.saturating_sub(4).max(28));
@@ -324,23 +357,35 @@ pub fn render_info_popup(
     let rect = centered(area, inner_w + 1, inner_h); // +1 for left padding
 
     let border = accent_style(accent);
-    let block = Block::default()
+    // Inner geometry depends only on the borders (titles render on the border row).
+    let inner = Block::default().borders(Borders::ALL).inner(rect);
+    // Pad one column on the left
+    let text_area = Rect::new(inner.x + 1, inner.y, inner.width.saturating_sub(1), inner.height);
+
+    let total = wrapped_height(&lines, text_area.width);
+    let max_scroll = total.saturating_sub(text_area.height);
+    let scroll = scroll.min(max_scroll);
+    let para = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
+
+    let mut block = Block::default()
         .borders(Borders::ALL)
         .border_style(border)
         .title(Title::from(Span::styled(
             format!(" {title} "),
             border.add_modifier(Modifier::BOLD),
         )).alignment(Alignment::Center));
-    let inner = block.inner(rect);
+    if max_scroll > 0 {
+        block = block.title(
+            Title::from(Span::styled(" ↑↓ scroll ", border))
+                .position(Position::Bottom)
+                .alignment(Alignment::Right),
+        );
+    }
 
     frame.render_widget(Clear, rect);
     frame.render_widget(block, rect);
-    // Pad one column on the left
-    let text_area = Rect::new(inner.x + 1, inner.y, inner.width.saturating_sub(1), inner.height);
-    frame.render_widget(
-        Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false }),
-        text_area,
-    );
+    frame.render_widget(para.scroll((scroll, 0)), text_area);
+    scroll
 }
 
 /// Render the artist-info popup: pixelated picture on the left, name +
@@ -351,7 +396,8 @@ pub fn render_artist_popup(
     detail: Option<&ArtistDetail>,
     art: Option<&CoverArt>,
     accent: Option<(u8, u8, u8)>,
-) {
+    scroll: u16,
+) -> u16 {
     let area = frame.area();
     let dim = Style::new().fg(Color::DarkGray);
     let bold_accent = accent_style(accent).add_modifier(Modifier::BOLD);
@@ -387,14 +433,35 @@ pub fn render_artist_popup(
     let rect = centered(area, inner_w, inner_h);
 
     let border = accent_style(accent);
-    let block = Block::default()
+    // Inner geometry depends only on the borders (titles render on the border row).
+    let inner = Block::default().borders(Borders::ALL).inner(rect);
+
+    // Work out where the bio text goes (and its width) so scroll can be clamped.
+    let info_area = if pic_col > 0 {
+        Layout::horizontal([Constraint::Length(pic_col), Constraint::Min(0)]).split(inner)[1]
+    } else {
+        Rect::new(inner.x + 1, inner.y, inner.width.saturating_sub(1), inner.height)
+    };
+
+    let total = wrapped_height(&info, info_area.width);
+    let max_scroll = total.saturating_sub(info_area.height);
+    let scroll = scroll.min(max_scroll);
+    let para = Paragraph::new(Text::from(info)).wrap(Wrap { trim: true }).scroll((scroll, 0));
+
+    let mut block = Block::default()
         .borders(Borders::ALL)
         .border_style(border)
         .title(Title::from(Span::styled(
             " Artist ",
             border.add_modifier(Modifier::BOLD),
         )).alignment(Alignment::Center));
-    let inner = block.inner(rect);
+    if max_scroll > 0 {
+        block = block.title(
+            Title::from(Span::styled(" ↑↓ scroll ", border))
+                .position(Position::Bottom)
+                .alignment(Alignment::Right),
+        );
+    }
 
     frame.render_widget(Clear, rect);
     frame.render_widget(block, rect);
@@ -405,19 +472,41 @@ pub fn render_artist_popup(
             Constraint::Min(0),
         ])
         .split(inner);
-        frame.render_widget(
-            Paragraph::new(Text::from(cover_lines.to_vec())),
-            cols[0],
-        );
-        frame.render_widget(
-            Paragraph::new(Text::from(info)).wrap(Wrap { trim: true }),
-            cols[1],
-        );
+        frame.render_widget(Paragraph::new(Text::from(cover_lines.to_vec())), cols[0]);
+        frame.render_widget(para, cols[1]);
     } else {
-        let text_area = Rect::new(inner.x + 1, inner.y, inner.width.saturating_sub(1), inner.height);
-        frame.render_widget(
-            Paragraph::new(Text::from(info)).wrap(Wrap { trim: true }),
-            text_area,
-        );
+        frame.render_widget(para, info_area);
+    }
+    scroll
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(s: &str) -> Line<'static> {
+        Line::from(s.to_string())
+    }
+
+    #[test]
+    fn wrapped_height_single_short_line() {
+        assert_eq!(wrapped_height(&[line("hello world")], 40), 1);
+    }
+
+    #[test]
+    fn wrapped_height_wraps_on_word_boundary() {
+        // "aaaa bbbb" fills width 9, "cccc" spills to a second row.
+        assert_eq!(wrapped_height(&[line("aaaa bbbb cccc")], 9), 2);
+    }
+
+    #[test]
+    fn wrapped_height_hard_wraps_long_word() {
+        // An 8-char word at width 3 needs ceil(8/3) = 3 rows.
+        assert_eq!(wrapped_height(&[line("aaaaaaaa")], 3), 3);
+    }
+
+    #[test]
+    fn wrapped_height_sums_multiple_lines() {
+        assert_eq!(wrapped_height(&[line("one"), line(""), line("two")], 40), 3);
     }
 }

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -232,7 +232,7 @@ fn field(label: &str, value: String, accent: Option<(u8, u8, u8)>) -> Line<'stat
 /// Build the body lines for the track-info popup.
 pub fn build_track_info_lines(
     track: &TrackInfo,
-    credits: Option<&Vec<Credit>>,
+    credits: Option<&[Credit]>,
     accent: Option<(u8, u8, u8)>,
 ) -> Vec<Line<'static>> {
     let dim = Style::new().fg(Color::DarkGray);

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -77,19 +77,21 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
 
     // ── Border + controls (only when show_controls) ───────────────────────────
     let inner = if state.show_controls {
-        let block_w = cover_col_w + right_col_w + 2; // +2 borders
-        let block_h = right_rows.max(cover_rows) + 2; // +2 borders
-        let x = terminal.x + terminal.width.saturating_sub(block_w) / 2;
-        let y = terminal.y + terminal.height.saturating_sub(block_h) / 2;
-        let area = Rect::new(x, y, block_w.min(terminal.width), block_h.min(terminal.height));
-
         let hint_text = if state.is_local {
             "← prev  Spc pause  → next  ↑↓ vol  i info  a artist  q/Esc quit"
         } else {
             "← prev  Spc pause  → next  ↑↓ vol  d download  r radio  i info  a artist  q/Esc quit"
         };
-        let controls = Title::from(Line::styled(hint_text, dim))
-            .alignment(Alignment::Center);
+        let hint_line = Line::styled(hint_text, dim);
+        // The box must fit the cover+info columns *and* the controls hint in the
+        // border title, else a long hint is clipped at both ends.
+        let block_w = (cover_col_w + right_col_w + 2).max(hint_line.width() as u16 + 2);
+        let block_h = right_rows.max(cover_rows) + 2; // +2 borders
+        let x = terminal.x + terminal.width.saturating_sub(block_w) / 2;
+        let y = terminal.y + terminal.height.saturating_sub(block_h) / 2;
+        let area = Rect::new(x, y, block_w.min(terminal.width), block_h.min(terminal.height));
+
+        let controls = Title::from(hint_line).alignment(Alignment::Center);
         let outer = Block::default()
             .borders(Borders::ALL)
             .border_style(dim)
@@ -284,9 +286,12 @@ pub fn build_track_info_lines(
         }
         Some(c) => {
             lines.push(Line::from(Span::styled("Credits", bold_accent)));
+            // Pad role labels to the longest role (+2) so values never collide
+            // with long roles like "Mixing Engineer" or "Drum Programmer".
+            let role_w = c.iter().map(|cr| cr.role.chars().count()).max().unwrap_or(0).max(9) + 2;
             for credit in c {
                 lines.push(Line::from(vec![
-                    Span::styled(format!("{:<11}", credit.role), dim),
+                    Span::styled(format!("{:<role_w$}", credit.role), dim),
                     Span::styled(credit.names.join(", "), Style::new().fg(Color::Gray)),
                 ]));
             }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -28,10 +28,11 @@ use symphonia::core::io::{MediaSource, MediaSourceStream};
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 
-use crate::api::{TidalClient, TrackInfo};
+use crate::api::{ArtistDetail, Credit, TidalClient, TrackInfo};
+use crate::auth::Session;
 use crate::color_state::{self, ColorState};
 use crate::config;
-use crate::cover::{render_cover, render_placeholder, ART_CHARS};
+use crate::cover::{render_cover, render_placeholder, CoverArt, ART_CHARS};
 use crate::panel::{self, PanelState};
 use crate::spectrum::{self, FFT_SIZE, NUM_BARS};
 
@@ -533,6 +534,7 @@ pub fn run(
         volume,
         false,
         already_saved,
+        Some(client.session.clone()),
     )?;
 
     download_done.store(true, Ordering::Relaxed); // signal dl thread to stop
@@ -569,6 +571,7 @@ pub fn run_local(
         volume,
         true,
         false,
+        None,
     )
 }
 
@@ -647,6 +650,7 @@ fn play(
     volume: Arc<Mutex<f32>>,
     is_local: bool,
     already_saved: bool,
+    session: Option<Session>,
 ) -> Result<String> {
     let cfg = config::load();
 
@@ -909,6 +913,15 @@ fn play(
     let mut beat_idx: usize = 0;
     let band_edges = spectrum::compute_band_edges(sample_rate);
 
+    // ── Info popups (lazily fetched in the background on first open) ───────────
+    let mut show_track_info = false;
+    let mut show_artist_info = false;
+    let credits: Arc<Mutex<Option<Vec<Credit>>>> = Arc::new(Mutex::new(None));
+    let credits_started = Arc::new(AtomicBool::new(false));
+    let artist_detail: Arc<Mutex<Option<ArtistDetail>>> = Arc::new(Mutex::new(None));
+    let artist_art: Arc<Mutex<Option<CoverArt>>> = Arc::new(Mutex::new(None));
+    let artist_started = Arc::new(AtomicBool::new(false));
+
     let result_str = loop {
         let elapsed_secs = current_sample.load(Ordering::Relaxed) as f64 / sample_rate as f64;
         let total_secs = if total_frames > 0 { total_frames as f64 / sample_rate as f64 } else { 0.0 };
@@ -978,7 +991,37 @@ fn play(
             queue_status,
         };
 
-        terminal.draw(|f| panel::render(f, &panel_state))?;
+        // Snapshot lazily-fetched popup data before the draw closure
+        let credits_snap = if show_track_info {
+            Some(credits.lock().unwrap_or_else(|e| e.into_inner()).clone())
+        } else {
+            None
+        };
+        let (artist_snap, artist_art_snap) = if show_artist_info {
+            (
+                artist_detail.lock().unwrap_or_else(|e| e.into_inner()).clone(),
+                artist_art.lock().unwrap_or_else(|e| e.into_inner()).clone(),
+            )
+        } else {
+            (None, None)
+        };
+
+        terminal.draw(|f| {
+            panel::render(f, &panel_state);
+            if show_track_info {
+                let credits_ref = credits_snap.as_ref().and_then(|c| c.as_ref());
+                let lines = panel::build_track_info_lines(track, credits_ref, bar_color);
+                panel::render_info_popup(f, "Track Info", lines, bar_color);
+            } else if show_artist_info {
+                panel::render_artist_popup(
+                    f,
+                    &track.artist_name,
+                    artist_snap.as_ref(),
+                    artist_art_snap.as_ref(),
+                    bar_color,
+                );
+            }
+        })?;
 
         // ── Keyboard ─────────────────────────────────────────────────────────
         if event::poll(Duration::from_millis(90))? {
@@ -986,8 +1029,14 @@ fn play(
                 if key.kind == KeyEventKind::Press {
                     match key.code {
                         KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => {
-                            stop_all.store(true, Ordering::Relaxed);
-                            break "quit".to_string();
+                            if show_track_info || show_artist_info {
+                                // First close any open info popup
+                                show_track_info = false;
+                                show_artist_info = false;
+                            } else {
+                                stop_all.store(true, Ordering::Relaxed);
+                                break "quit".to_string();
+                            }
                         }
                         KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Right => {
                             stop_all.store(true, Ordering::Relaxed);
@@ -1028,6 +1077,57 @@ fn play(
                         }
                         KeyCode::Char('?') => {
                             show_controls = !show_controls;
+                        }
+                        KeyCode::Char('i') | KeyCode::Char('I') => {
+                            show_artist_info = false;
+                            show_track_info = !show_track_info;
+                            // Lazily fetch credits the first time the popup opens
+                            if show_track_info && !credits_started.swap(true, Ordering::Relaxed) {
+                                match &session {
+                                    Some(sess) if !is_local => {
+                                        let sess = sess.clone();
+                                        let credits = credits.clone();
+                                        let tid = track.id;
+                                        thread::spawn(move || {
+                                            let client = TidalClient::new(sess);
+                                            let result = client.track_credits(tid).unwrap_or_default();
+                                            *credits.lock().unwrap_or_else(|e| e.into_inner()) = Some(result);
+                                        });
+                                    }
+                                    // No session (local file) — nothing to fetch
+                                    _ => *credits.lock().unwrap_or_else(|e| e.into_inner()) = Some(Vec::new()),
+                                }
+                            }
+                        }
+                        KeyCode::Char('a') | KeyCode::Char('A') => {
+                            show_track_info = false;
+                            show_artist_info = !show_artist_info;
+                            // Lazily fetch artist detail + picture the first time
+                            if show_artist_info && !artist_started.swap(true, Ordering::Relaxed) {
+                                match (&session, track.artist_id) {
+                                    (Some(sess), Some(aid)) => {
+                                        let sess = sess.clone();
+                                        let artist_detail = artist_detail.clone();
+                                        let artist_art = artist_art.clone();
+                                        thread::spawn(move || {
+                                            let client = TidalClient::new(sess);
+                                            let detail = client.artist_detail(aid).unwrap_or_default();
+                                            if let Some(pic) = &detail.picture {
+                                                if let Ok(bytes) = client.fetch_cover(pic, 320) {
+                                                    let art = render_cover(&bytes, ART_CHARS);
+                                                    *artist_art.lock().unwrap_or_else(|e| e.into_inner()) = Some(art);
+                                                }
+                                            }
+                                            *artist_detail.lock().unwrap_or_else(|e| e.into_inner()) = Some(detail);
+                                        });
+                                    }
+                                    // No session / unknown artist — show what we already have
+                                    _ => {
+                                        *artist_detail.lock().unwrap_or_else(|e| e.into_inner()) =
+                                            Some(ArtistDetail { name: track.artist_name.clone(), ..Default::default() });
+                                    }
+                                }
+                            }
                         }
                         KeyCode::Char('d') | KeyCode::Char('D') => {
                             if already_saved || is_local {

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -916,6 +916,10 @@ fn play(
     // ── Info popups (lazily fetched in the background on first open) ───────────
     let mut show_track_info = false;
     let mut show_artist_info = false;
+    // Vertical scroll offset for whichever popup is open (reset when toggling).
+    // Clamped to the content each frame by the render fn, which returns the
+    // applied offset so a press past the end doesn't strand the value.
+    let mut popup_scroll: u16 = 0;
     let credits: Arc<Mutex<Option<Vec<Credit>>>> = Arc::new(Mutex::new(None));
     let credits_started = Arc::new(AtomicBool::new(false));
     let artist_detail: Arc<Mutex<Option<ArtistDetail>>> = Arc::new(Mutex::new(None));
@@ -1006,22 +1010,27 @@ fn play(
             (None, None)
         };
 
+        let mut applied_scroll = popup_scroll;
         terminal.draw(|f| {
             panel::render(f, &panel_state);
             if show_track_info {
                 let credits_ref = credits_snap.as_ref().and_then(|c| c.as_deref());
                 let lines = panel::build_track_info_lines(track, credits_ref, bar_color);
-                panel::render_info_popup(f, "Track Info", lines, bar_color);
+                applied_scroll = panel::render_info_popup(f, "Track Info", lines, bar_color, popup_scroll);
             } else if show_artist_info {
-                panel::render_artist_popup(
+                applied_scroll = panel::render_artist_popup(
                     f,
                     &track.artist_name,
                     artist_snap.as_ref(),
                     artist_art_snap.as_ref(),
                     bar_color,
+                    popup_scroll,
                 );
             }
         })?;
+        // Adopt the clamped offset the popup actually used, so "up" responds
+        // immediately even after the user held "down" past the end.
+        popup_scroll = applied_scroll;
 
         // ── Keyboard ─────────────────────────────────────────────────────────
         if event::poll(Duration::from_millis(90))? {
@@ -1061,6 +1070,20 @@ fn play(
                                 });
                             }
                         }
+                        // While a popup is open, ↑/↓ scroll it instead of changing
+                        // volume (the popup overlays the whole UI). +/- always do volume.
+                        KeyCode::Up if show_track_info || show_artist_info => {
+                            popup_scroll = popup_scroll.saturating_sub(1);
+                        }
+                        KeyCode::Down if show_track_info || show_artist_info => {
+                            popup_scroll = popup_scroll.saturating_add(1);
+                        }
+                        KeyCode::PageUp if show_track_info || show_artist_info => {
+                            popup_scroll = popup_scroll.saturating_sub(10);
+                        }
+                        KeyCode::PageDown if show_track_info || show_artist_info => {
+                            popup_scroll = popup_scroll.saturating_add(10);
+                        }
                         KeyCode::Up | KeyCode::Char('+') | KeyCode::Char('=') => {
                             {
                                 let mut v = volume.lock().unwrap_or_else(|e| e.into_inner());
@@ -1081,6 +1104,7 @@ fn play(
                         KeyCode::Char('t') | KeyCode::Char('T') => {
                             show_artist_info = false;
                             show_track_info = !show_track_info;
+                            popup_scroll = 0; // start at the top each time
                             // Lazily fetch credits the first time the popup opens
                             if show_track_info && !credits_started.swap(true, Ordering::Relaxed) {
                                 match &session {
@@ -1102,6 +1126,7 @@ fn play(
                         KeyCode::Char('a') | KeyCode::Char('A') => {
                             show_track_info = false;
                             show_artist_info = !show_artist_info;
+                            popup_scroll = 0; // start at the top each time
                             // Lazily fetch artist detail + picture the first time
                             if show_artist_info && !artist_started.swap(true, Ordering::Relaxed) {
                                 match (&session, track.artist_id) {

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -1009,7 +1009,7 @@ fn play(
         terminal.draw(|f| {
             panel::render(f, &panel_state);
             if show_track_info {
-                let credits_ref = credits_snap.as_ref().and_then(|c| c.as_ref());
+                let credits_ref = credits_snap.as_ref().and_then(|c| c.as_deref());
                 let lines = panel::build_track_info_lines(track, credits_ref, bar_color);
                 panel::render_info_popup(f, "Track Info", lines, bar_color);
             } else if show_artist_info {
@@ -1109,9 +1109,14 @@ fn play(
                                         let sess = sess.clone();
                                         let artist_detail = artist_detail.clone();
                                         let artist_art = artist_art.clone();
+                                        let fallback_name = track.artist_name.clone();
                                         thread::spawn(move || {
                                             let client = TidalClient::new(sess);
-                                            let detail = client.artist_detail(aid).unwrap_or_default();
+                                            // On failure keep the known artist name so the popup
+                                            // header stays meaningful rather than going blank.
+                                            let detail = client.artist_detail(aid).unwrap_or_else(|_| {
+                                                ArtistDetail { name: fallback_name, ..Default::default() }
+                                            });
                                             if let Some(pic) = &detail.picture {
                                                 if let Ok(bytes) = client.fetch_cover(pic, 320) {
                                                     let art = render_cover(&bytes, ART_CHARS);

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -1078,7 +1078,7 @@ fn play(
                         KeyCode::Char('?') => {
                             show_controls = !show_controls;
                         }
-                        KeyCode::Char('i') | KeyCode::Char('I') => {
+                        KeyCode::Char('t') | KeyCode::Char('T') => {
                             show_artist_info = false;
                             show_track_info = !show_track_info;
                             // Lazily fetch credits the first time the popup opens


### PR DESCRIPTION
## Summary

Adds two in-player info popups, fetched lazily from Tidal:

- **`t`** — track info: title, version, explicit flag, artists, album + year, track/disc, duration, quality, popularity, ISRC, copyright, and per-track **credits** (producers, composers, engineers…).
- **`a`** — artist info: name, popularity, and **biography**, with the artist picture rendered in the same Braille/dither style as album art.

`q`/`Esc` closes an open popup first, then quits. Local files fall back to embedded metadata.

### Track info (`t`)
![track info popup](https://raw.githubusercontent.com/BrettKinny/lumitide/pr-screenshots/assets/pr/track-info.png)

### Artist info (`a`)
![artist info popup](https://raw.githubusercontent.com/BrettKinny/lumitide/pr-screenshots/assets/pr/artist-info.png)

## Implementation notes

- `api.rs`: `artist_id` / `version` / `explicit` / `popularity` added to `TrackInfo`; `picture` on `ArtistInfo`; new `Credit` / `ArtistDetail` types; `track_credits`, `artist_detail`, `artist_bio` client methods; `clean_bio` strips Tidal's `[wimpLink …]` markup while keeping link text. Unit tests cover the new parsing + `clean_bio`.
- `preview.rs`: extra data is fetched **in the background on first popup open**, so playback start is unaffected; popups are mutually exclusive; lock snapshots are taken before the draw closure.
- `panel.rs`: popup rendering. The controls overlay box now sizes to fit its hint, and credit role labels pad to the longest role so values never collide.

## Scrolling

While a popup is open, `↑`/`↓` (and `PgUp`/`PgDn`) scroll its contents instead of changing volume (`+`/`-` still adjust volume); a dim `↑↓ scroll` hint shows on the border when there's more to read. So long artist biographies are fully readable. Scroll height is clamped via a small self-contained word-wrap counter (`wrapped_height`, unit-tested) rather than ratatui's unstable `line_count`.

---

> **Heads-up for maintainers:** this shares `play()`'s plumbing with my likes PR (#10) — both pass a client into `play()` for off-thread work. They're independent features; whichever merges second needs a trivial unification (one `Option<TidalClient>` handle serves both the popups' fetches and the like calls). I'm happy to rebase whichever you take second.
