### PR TITLE
feat: add 's' to share — copy track link to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stream audio from your Tidal account directly in the terminal, with album art, a
 
 ![Lumitide demo](assets/demo.gif)
 
-**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`r` radio &nbsp;`?` controls &nbsp;`q/Esc` back
+**Playback:** `→/n` next &nbsp;`←/p` prev &nbsp;`Space` pause &nbsp;`↑/+` vol up &nbsp;`↓/-` vol down &nbsp;`d` download &nbsp;`s` share &nbsp;`r` radio &nbsp;`?` controls &nbsp;`q/Esc` back
 
 **Lists:** `↑↓` / `jk` navigate &nbsp;`Enter` play &nbsp;`d` queue for download &nbsp;`Esc/q` back
 

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -28,8 +28,21 @@ pub struct PanelState<'a> {
     pub show_controls: bool,
     pub show_controls_hint: bool,
     pub queue_status: Option<String>,
-    /// Transient "link copied" message shown in the info line for ~2s after `s`.
-    pub share_flash: Option<String>,
+    /// Transient `(message, is_error)` shown in the info line for ~2s after `s`.
+    pub share_flash: Option<(String, bool)>,
+}
+
+/// Style for a transient status/flash message in the info line: the accent color
+/// (album-art color, falling back to green) in bold for success, dim for errors.
+fn status_style(is_error: bool, bar_color: Option<(u8, u8, u8)>, dim: Style) -> Style {
+    if is_error {
+        dim
+    } else {
+        match bar_color {
+            Some((r, g, b)) => Style::new().fg(Color::Rgb(r, g, b)).add_modifier(Modifier::BOLD),
+            None => Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
+        }
+    }
 }
 
 pub fn render(frame: &mut Frame, state: &PanelState) {
@@ -84,7 +97,7 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
         let area = Rect::new(x, y, block_w.min(terminal.width), block_h.min(terminal.height));
 
         let hint_text = if state.is_local {
-            "← prev  Spc pause  → next  ↑↓ vol  q/Esc quit"
+            "← prev  Spc pause  → next  ↑↓ vol  s share  q/Esc quit"
         } else {
             "← prev  Spc pause  → next  ↑↓ vol  d download  s share  r radio  q/Esc quit"
         };
@@ -149,40 +162,29 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
         ));
     }
 
-    if !state.dl_status.is_empty() && !state.dl_status.starts_with('⬇') {
-        // Show status ("✓ Saved", "✓ Saving...", "✗ Error") in the info line
-        let status_style = if state.dl_status.starts_with('✓') {
-            match state.bar_color {
-                Some((r, g, b)) => Style::new().fg(Color::Rgb(r, g, b)).add_modifier(Modifier::BOLD),
-                None => Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
-            }
-        } else {
-            dim // error states
-        };
-        time_line.push(Span::styled(
-            format!("  vol {}%{}", vol_pct, pause_str),
-            Style::new().add_modifier(Modifier::BOLD),
-        ));
-        time_line.push(Span::styled(
-            format!("  {}", state.dl_status),
-            status_style,
-        ));
+    // One status slot on the info line. The transient share flash (~2s) takes
+    // precedence over the download status so the two never collide on the
+    // fixed-width right column. `(text, is_error)`.
+    let status: Option<(String, bool)> = if let Some((msg, is_err)) = &state.share_flash {
+        Some((msg.clone(), *is_err))
+    } else if !state.dl_status.is_empty() && !state.dl_status.starts_with('⬇') {
+        // "✓ Saved" / "✓ Saving..." are success; anything else ("✗ …") is an error.
+        Some((state.dl_status.to_string(), !state.dl_status.starts_with('✓')))
     } else {
+        None
+    };
+
+    let vol_style = if status.is_some() {
+        Style::new().add_modifier(Modifier::BOLD)
+    } else {
+        Style::new()
+    };
+    time_line.push(Span::styled(format!("  vol {}%{}", vol_pct, pause_str), vol_style));
+    if let Some((text, is_err)) = status {
         time_line.push(Span::styled(
-            format!("  vol {}%{}", vol_pct, pause_str),
-            Style::new(),
+            format!("  {}", text),
+            status_style(is_err, state.bar_color, dim),
         ));
-    }
-    if let Some(msg) = &state.share_flash {
-        let flash_style = if msg.starts_with('✗') {
-            dim
-        } else {
-            match state.bar_color {
-                Some((r, g, b)) => Style::new().fg(Color::Rgb(r, g, b)).add_modifier(Modifier::BOLD),
-                None => Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
-            }
-        };
-        time_line.push(Span::styled(format!("  {}", msg), flash_style));
     }
     right.push(Line::from(time_line));
     right.push(Line::raw(""));

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -28,6 +28,8 @@ pub struct PanelState<'a> {
     pub show_controls: bool,
     pub show_controls_hint: bool,
     pub queue_status: Option<String>,
+    /// Transient "link copied" message shown in the info line for ~2s after `s`.
+    pub share_flash: Option<String>,
 }
 
 pub fn render(frame: &mut Frame, state: &PanelState) {
@@ -84,7 +86,7 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
         let hint_text = if state.is_local {
             "← prev  Spc pause  → next  ↑↓ vol  q/Esc quit"
         } else {
-            "← prev  Spc pause  → next  ↑↓ vol  d download  r radio  q/Esc quit"
+            "← prev  Spc pause  → next  ↑↓ vol  d download  s share  r radio  q/Esc quit"
         };
         let controls = Title::from(Line::styled(hint_text, dim))
             .alignment(Alignment::Center);
@@ -170,6 +172,17 @@ pub fn render(frame: &mut Frame, state: &PanelState) {
             format!("  vol {}%{}", vol_pct, pause_str),
             Style::new(),
         ));
+    }
+    if let Some(msg) = &state.share_flash {
+        let flash_style = if msg.starts_with('✗') {
+            dim
+        } else {
+            match state.bar_color {
+                Some((r, g, b)) => Style::new().fg(Color::Rgb(r, g, b)).add_modifier(Modifier::BOLD),
+                None => Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
+            }
+        };
+        time_line.push(Span::styled(format!("  {}", msg), flash_style));
     }
     right.push(Line::from(time_line));
     right.push(Line::raw(""));

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -707,8 +707,8 @@ fn play(
         if already_saved { "✓ Saved".to_string() } else { String::new() }
     ));
     let dl_flash_until: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
-    // Transient (message, expiry) shown in the info line after pressing `s` (share).
-    let share_flash: Arc<Mutex<Option<(String, Instant)>>> = Arc::new(Mutex::new(None));
+    // Transient (message, is_error, expiry) shown in the info line after pressing `s` (share).
+    let share_flash: Arc<Mutex<Option<(String, bool, Instant)>>> = Arc::new(Mutex::new(None));
 
     let drop_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
     let beat_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
@@ -955,7 +955,7 @@ fn play(
         let share_msg = {
             let mut g = share_flash.lock().unwrap_or_else(|e| e.into_inner());
             match g.as_ref() {
-                Some((m, t)) if Instant::now() < *t => Some(m.clone()),
+                Some((m, err, t)) if Instant::now() < *t => Some((m.clone(), *err)),
                 Some(_) => { *g = None; None } // expired
                 None => None,
             }
@@ -1042,17 +1042,17 @@ fn play(
                             show_controls = !show_controls;
                         }
                         KeyCode::Char('s') | KeyCode::Char('S') => {
-                            let msg = if is_local {
-                                "🔗 Local track — no link".to_string()
+                            let (msg, is_err) = if is_local {
+                                ("🔗 Local track — no link".to_string(), false)
                             } else {
                                 let url = format!("https://tidal.com/browse/track/{}", track.id);
                                 match crate::utils::copy_to_clipboard(&url) {
-                                    Ok(_)  => "🔗 Link copied".to_string(),
-                                    Err(_) => "✗ Copy failed".to_string(),
+                                    Ok(_)  => ("🔗 Link copied".to_string(), false),
+                                    Err(e) => (format!("✗ Copy failed: {e}"), true),
                                 }
                             };
                             *share_flash.lock().unwrap_or_else(|e| e.into_inner()) =
-                                Some((msg, Instant::now() + Duration::from_secs(2)));
+                                Some((msg, is_err, Instant::now() + Duration::from_secs(2)));
                         }
                         KeyCode::Char('d') | KeyCode::Char('D') => {
                             if already_saved || is_local {

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -707,6 +707,8 @@ fn play(
         if already_saved { "✓ Saved".to_string() } else { String::new() }
     ));
     let dl_flash_until: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+    // Transient (message, expiry) shown in the info line after pressing `s` (share).
+    let share_flash: Arc<Mutex<Option<(String, Instant)>>> = Arc::new(Mutex::new(None));
 
     let drop_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
     let beat_times: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
@@ -950,6 +952,15 @@ fn play(
         let dl_b = dl_bytes.load(Ordering::Relaxed);
         let dl_t = dl_total.load(Ordering::Relaxed);
 
+        let share_msg = {
+            let mut g = share_flash.lock().unwrap_or_else(|e| e.into_inner());
+            match g.as_ref() {
+                Some((m, t)) if Instant::now() < *t => Some(m.clone()),
+                Some(_) => { *g = None; None } // expired
+                None => None,
+            }
+        };
+
         // Build visualisation lines
         let spec = spec_buf.lock().unwrap_or_else(|e| e.into_inner()).clone();
         let vis = panel::build_vis_lines(
@@ -976,6 +987,7 @@ fn play(
             show_controls,
             show_controls_hint: cfg.show_controls_hint,
             queue_status,
+            share_flash: share_msg,
         };
 
         terminal.draw(|f| panel::render(f, &panel_state))?;
@@ -1028,6 +1040,19 @@ fn play(
                         }
                         KeyCode::Char('?') => {
                             show_controls = !show_controls;
+                        }
+                        KeyCode::Char('s') | KeyCode::Char('S') => {
+                            let msg = if is_local {
+                                "🔗 Local track — no link".to_string()
+                            } else {
+                                let url = format!("https://tidal.com/browse/track/{}", track.id);
+                                match crate::utils::copy_to_clipboard(&url) {
+                                    Ok(_)  => "🔗 Link copied".to_string(),
+                                    Err(_) => "✗ Copy failed".to_string(),
+                                }
+                            };
+                            *share_flash.lock().unwrap_or_else(|e| e.into_inner()) =
+                                Some((msg, Instant::now() + Duration::from_secs(2)));
                         }
                         KeyCode::Char('d') | KeyCode::Char('D') => {
                             if already_saved || is_local {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,21 @@
+use std::io::Write;
 use std::path::PathBuf;
+
+use base64::Engine;
+
+/// Copy `text` to the system clipboard via the OSC 52 terminal escape.
+///
+/// Dependency-free and works over SSH — the terminal owns the clipboard, so the
+/// contents survive after Lumitide exits. Requires an OSC 52-capable terminal
+/// (Alacritty, Kitty, iTerm2, WezTerm, Windows Terminal, foot, …). Inside tmux
+/// the user must set `set-clipboard on` for the escape to be forwarded.
+pub fn copy_to_clipboard(text: &str) -> std::io::Result<()> {
+    let b64 = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    let seq = format!("\x1b]52;c;{b64}\x07");
+    let mut out = std::io::stdout();
+    out.write_all(seq.as_bytes())?;
+    out.flush()
+}
 
 /// Remove filesystem-unsafe characters and truncate to 200 chars.
 pub fn safe_filename(name: &str) -> String {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,8 +5,9 @@ use base64::Engine;
 
 /// Copy `text` to the system clipboard via the OSC 52 terminal escape.
 ///
-/// Dependency-free and works over SSH — the terminal owns the clipboard, so the
-/// contents survive after Lumitide exits. Requires an OSC 52-capable terminal
+/// No OS clipboard library or daemon required, and it works over SSH — the
+/// terminal owns the clipboard, so the contents survive after Lumitide exits.
+/// Requires an OSC 52-capable terminal
 /// (Alacritty, Kitty, iTerm2, WezTerm, Windows Terminal, foot, …). Inside tmux
 /// the user must set `set-clipboard on` for the escape to be forwarded.
 pub fn copy_to_clipboard(text: &str) -> std::io::Result<()> {


### PR DESCRIPTION
## What

Adds a `s` / `S` shortcut on the now-playing screen that copies a shareable Tidal link for the current track to the system clipboard, with a brief `🔗 Link copied` confirmation in the info line.

The link uses the form the Tidal web app produces: `https://tidal.com/browse/track/<id>`.

## How

Clipboard write uses an **OSC 52 terminal escape** rather than a native clipboard crate:

- **No new dependency** — reuses the existing `base64` dep.
- **Works over SSH** and the link **persists after the app exits**, since the terminal (not the process) owns the clipboard.
- Requires an OSC 52-capable terminal — Alacritty, Kitty, iTerm2, WezTerm, Windows Terminal, foot, etc. (the truecolor terminals the project already targets). Inside tmux, `set -g set-clipboard on` is needed to forward it.

Local files have no Tidal id, so `s` flashes `🔗 Local track — no link` and leaves the clipboard untouched.

## Changes

- `src/utils.rs` — new `copy_to_clipboard()` (OSC 52, reuses base64).
- `src/preview.rs` — `s`/`S` key handling + a 2s transient flash state.
- `src/panel.rs` — render the flash in the info line (independent of download status); add `s share` to the `?` controls overlay.
- `README.md` — `s` share added to the Playback controls line.

## Notes

OSC 52 is silent — if a terminal doesn't support it the flash still reads "copied", since success can't be detected. This is inherent to the dependency-free approach.


## Screenshot

Now-playing screen just after pressing `s` — the `🔗 Link copied` confirmation appears in the info line:

![Share — link copied](https://raw.githubusercontent.com/BrettKinny/lumitide/media/share-screenshot/.prmedia/share-demo.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
