### PR TITLE
feat: lossless HiRes FLAC on Linux/macOS via DASH remux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A terminal music player for Tidal, written in Rust.
 Stream audio from your Tidal account directly in the terminal, with album art, a live spectrum visualizer, beat/drop detection, and a background download queue.
 
 > [!NOTE]
-> **Audio quality is platform-dependent.** Windows uses the Tidal desktop app auth flow and streams/downloads **lossless FLAC**. Linux and macOS use a device code flow and receive **MP4 (HIGH quality / AAC)**. Native FLAC support for Linux/macOS is planned.
+> **Audio quality is platform-dependent.** Windows uses the Tidal desktop app auth flow and streams/downloads **lossless FLAC**. On Linux and macOS, HiRes-tagged tracks now stream/download as **lossless FLAC (up to 24-bit)** via Tidal's DASH delivery (requires `ffmpeg`); non-HiRes tracks fall back to **MP4 (HIGH quality / AAC)**.
 > See [docs/how-flac-works.md](docs/how-flac-works.md) for a full technical write-up of the auth flow and stream decryption.
 
 ![Lumitide demo](assets/demo.gif)
@@ -21,7 +21,7 @@ Stream audio from your Tidal account directly in the terminal, with album art, a
 
 ## Features
 
-- **Stream** audio from Tidal in real time — **lossless FLAC** on Windows, **MP4/AAC** (HIGH quality) on Linux/macOS
+- **Stream** audio from Tidal in real time — **lossless FLAC** on Windows, and on Linux/macOS for HiRes tracks (up to 24-bit, via DASH); **MP4/AAC** (HIGH quality) for non-HiRes tracks on Linux/macOS
 - **Album cover art** rendered as Braille characters in the terminal
 - **Spectrum visualizer** with peak-hold bars and beat/drop detection
 - **Album-art color theming** — title, spectrum bars, and transition arrows all take their color from the current cover
@@ -112,6 +112,19 @@ cargo build --release
 sudo apt install libasound2-dev  # Debian / Ubuntu
 sudo dnf install alsa-lib-devel  # Fedora
 ```
+
+**Linux / macOS HiRes FLAC** is delivered as segmented DASH and remuxed to a
+native `.flac` with [`ffmpeg`](https://ffmpeg.org/). To get lossless FLAC, install it
+and make sure it's on your `PATH`:
+```sh
+sudo apt install ffmpeg     # Debian / Ubuntu
+sudo dnf install ffmpeg     # Fedora
+brew install ffmpeg         # macOS
+```
+`ffmpeg` is **optional**: if it isn't installed (or you turn HiRes FLAC off in the
+config), Lumitide simply falls back to the previous MP4/AAC (HIGH) behaviour — nothing
+breaks. You can toggle it via `HiRes FLAC` in the interactive config, or the
+`hires_flac` field in `~/.config/lumitide/config.json`.
 
 ## Authentication
 

--- a/docs/how-flac-works.md
+++ b/docs/how-flac-works.md
@@ -6,7 +6,7 @@ Tidal changed their streaming API in a way that broke lossless audio for every t
 
 ## What broke and why
 
-Third-party clients were using a public OAuth client (`fX2JxdmntZWK0ixT`) with a device code grant. The tokens it issues carry `"at": "BROWSER"` in the JWT payload. At some point Tidal started gating lossless streams on `"at": "INTERNAL"` tokens only — BROWSER tokens now silently fall back to MP4/AAC.
+Third-party clients were using a public OAuth client (`fX2JxdmntZWK0ixT`) with a device code grant. Historically the tokens it issued carried `"at": "BROWSER"` in the JWT payload, and Tidal gated lossless streams on `"at": "INTERNAL"` tokens only, so BROWSER tokens silently fell back to MP4/AAC. (Tidal has since started issuing `"at": "INTERNAL"` tokens to this client too — see [Lossless FLAC on Linux / macOS](#lossless-flac-on-linux--macos) below.)
 
 Most clients have open issues about this. The common workaround is to manually swap in client IDs scraped from other Tidal apps — brittle, and those IDs get rotated.
 
@@ -76,7 +76,27 @@ nonce = plain[16:24]
 
 | Platform | Auth flow | Quality |
 |----------|-----------|---------|
-| Windows  | PKCE (browser auto-redirect) | LOSSLESS FLAC |
-| Linux / macOS | Device code | HIGH (MP4/AAC) |
+| Windows  | PKCE (browser auto-redirect) | LOSSLESS FLAC (bts / `OLD_AES`) |
+| Linux / macOS | Device code | HiRes tracks → LOSSLESS FLAC (DASH); other tracks → HIGH (MP4/AAC) |
 
-FLAC on Linux/macOS requires registering a `tidal://` URI handler, which varies across desktop environments. It's on the roadmap.
+### Lossless FLAC on Linux / macOS
+
+It turned out the `tidal://` URI handler was never needed. The device-code client
+(`fX2JxdmntZWK0ixT`) already issues `"at": "INTERNAL"` tokens, and on a HiRes-capable
+account Tidal will serve lossless FLAC to it — just via a **different delivery path**
+than Windows:
+
+- Request `audioquality=HI_RES_LOSSLESS` (plain `LOSSLESS` is silently downgraded to
+  AAC on this client).
+- For HiRes-tagged tracks the playback endpoint returns a **DASH** manifest
+  (`application/dash+xml`) with `codecs="flac"`, up to 24-bit — **not** the encrypted
+  `bts` / `OLD_AES` single-URL manifest Windows gets. There is no `keyId` and no
+  encryption: the segments are plain FLAC-in-fragmented-MP4.
+- Lumitide parses the DASH `SegmentTemplate` (init segment + numbered media segments),
+  downloads and concatenates them, then **remuxes to a native `.flac`** with
+  `ffmpeg -c:a copy` — a lossless stream-copy that rewraps the container without
+  decoding or re-encoding the audio. (This is why `ffmpeg` is a runtime requirement on
+  Linux/macOS.)
+
+Non-HiRes (CD-quality `LOSSLESS`-only) tracks are still served to this client as
+MP4/AAC and saved as `.m4a`.

--- a/src/api.rs
+++ b/src/api.rs
@@ -15,10 +15,18 @@ pub struct EncryptionInfo {
     pub nonce: [u8; 8],
 }
 
-/// Result of a stream_url call: the CDN URL plus optional encryption info.
-pub struct StreamInfo {
-    pub url: String,
-    pub encryption: Option<EncryptionInfo>,
+/// Result of a stream_url call: how Tidal is delivering this track's audio.
+pub enum StreamInfo {
+    /// A single CDN URL (Tidal "bts" manifest), optionally AES-128-CTR encrypted.
+    /// Covers Windows lossless FLAC and the MP4/AAC fallback on all platforms.
+    Single {
+        url: String,
+        encryption: Option<EncryptionInfo>,
+    },
+    /// A multi-segment DASH stream (HiRes FLAC): the init segment followed by the
+    /// media segments, in order. Concatenate and remux to native FLAC — these are
+    /// unencrypted, so no decryption is needed.
+    Dash { segments: Vec<String> },
 }
 
 #[derive(Debug, Clone)]
@@ -181,8 +189,17 @@ impl TidalClient {
     pub fn stream_url(&self, id: u64) -> Result<StreamInfo> {
         #[cfg(target_os = "windows")]
         let quality = "LOSSLESS";
+        // Linux/macOS: request HI_RES_LOSSLESS only when the user wants FLAC AND
+        // ffmpeg is available to remux the DASH segments. Tidal serves HiRes-tagged
+        // tracks as unencrypted DASH FLAC (up to 24-bit); non-HiRes tracks fall back
+        // to AAC. If FLAC is disabled or ffmpeg is missing we ask for HIGH, which
+        // keeps the original MP4/AAC behaviour with no ffmpeg dependency.
         #[cfg(not(target_os = "windows"))]
-        let quality = "HIGH";
+        let quality = if crate::config::load().hires_flac && ffmpeg_available() {
+            "HI_RES_LOSSLESS"
+        } else {
+            "HIGH"
+        };
 
         let resp = self.get(
             &format!("tracks/{}/playbackinfopostpaywall", id),
@@ -225,16 +242,22 @@ impl TidalClient {
             } else {
                 None
             };
-            Ok(StreamInfo { url, encryption })
+            Ok(StreamInfo::Single { url, encryption })
         } else if info.manifest_mime_type.contains("dash") {
             let xml = String::from_utf8_lossy(&decoded);
-            let url = xml.lines()
-                .find(|l| l.contains("<BaseURL>"))
-                .and_then(|l| l.split("<BaseURL>").nth(1))
-                .and_then(|l| l.split("</BaseURL>").next())
-                .map(|s| s.trim().to_string())
-                .ok_or_else(|| anyhow!("Could not extract BaseURL from DASH manifest"))?;
-            Ok(StreamInfo { url, encryption: None })
+            // HiRes FLAC is delivered as a multi-segment DASH SegmentTemplate.
+            if let Some(segments) = parse_dash_segments(&xml) {
+                Ok(StreamInfo::Dash { segments })
+            } else {
+                // Old-style single-segment DASH: a lone <BaseURL>.
+                let url = xml.lines()
+                    .find(|l| l.contains("<BaseURL>"))
+                    .and_then(|l| l.split("<BaseURL>").nth(1))
+                    .and_then(|l| l.split("</BaseURL>").next())
+                    .map(|s| s.trim().to_string())
+                    .ok_or_else(|| anyhow!("Could not extract segments or BaseURL from DASH manifest"))?;
+                Ok(StreamInfo::Single { url, encryption: None })
+            }
         } else {
             Err(anyhow!("Unknown manifest type: {}", info.manifest_mime_type))
         }
@@ -579,6 +602,108 @@ fn decrypt_security_token(key_id: &str) -> Result<EncryptionInfo> {
     Ok(EncryptionInfo { key, nonce })
 }
 
+// ─── DASH (HiRes FLAC) ───────────────────────────────────────────────────────
+
+/// Parse a Tidal DASH `SegmentTemplate` manifest into an ordered list of segment
+/// URLs (the init segment first, then each media segment). Returns `None` if the
+/// manifest isn't SegmentTemplate-based, so the caller can fall back to a single
+/// `<BaseURL>`.
+fn parse_dash_segments(xml: &str) -> Option<Vec<String>> {
+    let st = xml.find("<SegmentTemplate")?;
+    let tag_end = xml[st..].find('>')? + st;
+    let tag = &xml[st..tag_end];
+
+    let init = xml_attr(tag, "initialization")?;
+    let media = xml_attr(tag, "media")?;
+    let start: u64 = xml_attr(tag, "startNumber").and_then(|v| v.parse().ok()).unwrap_or(1);
+
+    // Count media segments from the SegmentTimeline: each <S> element covers
+    // (1 + r) segments, where r ("repeat") defaults to 0.
+    let timeline = &xml[xml.find("<SegmentTimeline")?..];
+    let mut count: u64 = 0;
+    let mut rest = timeline;
+    while let Some(p) = rest.find("<S ") {
+        let end = rest[p..].find("/>")? + p;
+        let s_el = &rest[p..end];
+        let r: u64 = xml_attr(s_el, "r").and_then(|v| v.parse().ok()).unwrap_or(0);
+        count += 1 + r;
+        rest = &rest[end + 2..];
+    }
+    if count == 0 {
+        return None;
+    }
+
+    let mut segments = Vec::with_capacity(count as usize + 1);
+    segments.push(init.to_string());
+    for n in start..start + count {
+        segments.push(media.replace("$Number$", &n.to_string()));
+    }
+    Some(segments)
+}
+
+/// Whether `ffmpeg` is on PATH. Probed once and cached — it gates whether we even
+/// request the DASH/FLAC tier, so a machine without ffmpeg behaves exactly as before
+/// (MP4/AAC) instead of failing on HiRes tracks.
+#[cfg(not(target_os = "windows"))]
+fn ffmpeg_available() -> bool {
+    use std::sync::OnceLock;
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        std::process::Command::new("ffmpeg")
+            .arg("-version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    })
+}
+
+/// Read the value of an XML attribute `name="..."` from a single element string.
+fn xml_attr<'a>(element: &'a str, name: &str) -> Option<&'a str> {
+    let needle = format!("{}=\"", name);
+    let start = element.find(&needle)? + needle.len();
+    let end = element[start..].find('"')? + start;
+    Some(&element[start..end])
+}
+
+/// Download an ordered list of DASH segments, concatenate them, and remux to a
+/// native FLAC file at `dest` using ffmpeg. This is a lossless stream-copy
+/// (`-c:a copy`) — the FLAC audio is never decoded or re-encoded, only rewrapped
+/// from the fragmented-MP4 container into a `.flac` container. `dest` should end
+/// in `.flac`; `ffmpeg` must be on PATH.
+pub fn fetch_dash_flac(segments: &[String], dest: &std::path::Path) -> Result<()> {
+    use std::io::Write;
+    let http = reqwest::blocking::Client::builder()
+        .user_agent(crate::auth::TIDAL_UA)
+        .build()?;
+
+    let part = dest.with_extension("mp4.part");
+    {
+        let mut f = std::fs::File::create(&part)?;
+        for seg in segments {
+            let bytes = http.get(seg).send()?.error_for_status()?.bytes()?;
+            f.write_all(&bytes)?;
+        }
+    }
+
+    let status = std::process::Command::new("ffmpeg")
+        .args(["-v", "error", "-i"])
+        .arg(&part)
+        .args(["-c:a", "copy", "-y"])
+        .arg(dest)
+        .status();
+    let _ = std::fs::remove_file(&part);
+
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        Ok(s) => Err(anyhow!("ffmpeg remux failed (exit {:?})", s.code())),
+        Err(e) => Err(anyhow!(
+            "ffmpeg not found ({e}). Install ffmpeg to play/download HiRes FLAC on Linux/macOS."
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -646,6 +771,57 @@ mod tests {
         assert_eq!(t.album_artist, "Solo");
     }
 
+    /// End-to-end HiRes path: session → stream_url (DASH) → fetch_dash_flac →
+    /// validate native FLAC. Run with:
+    ///   cargo test e2e_dash_flac -- --ignored --nocapture
+    #[test]
+    #[ignore = "requires a real Tidal session on disk + ffmpeg"]
+    fn e2e_dash_flac_download() {
+        let session = crate::auth::get_session().expect("load session");
+        let client = TidalClient::new(session);
+        let track_id = 19823990u64; // Daft Punk — Get Lucky (HIRES_LOSSLESS tagged)
+
+        let segments = match client.stream_url(track_id).expect("stream_url failed") {
+            StreamInfo::Dash { segments } => segments,
+            StreamInfo::Single { .. } => panic!("expected DASH HiRes manifest — is this a HiRes account/track?"),
+        };
+        println!("[1] DASH manifest: {} segments (init + media)", segments.len());
+        assert!(segments.len() > 1, "expected init + media segments");
+
+        let tmp = tempfile::Builder::new().suffix(".flac").tempfile().unwrap();
+        let dest = tmp.path().to_path_buf();
+        fetch_dash_flac(&segments, &dest).expect("fetch_dash_flac failed");
+
+        let mut head = [0u8; 4];
+        std::io::Read::read_exact(&mut std::fs::File::open(&dest).unwrap(), &mut head).unwrap();
+        let size = std::fs::metadata(&dest).unwrap().len();
+        println!("[2] wrote {} bytes, magic={:?}", size, &head);
+        assert_eq!(&head, b"fLaC", "output is not a native FLAC file");
+        assert!(size > 1_000_000, "FLAC file suspiciously small");
+        println!("[3] OK — native FLAC produced");
+    }
+
+    #[test]
+    fn dash_segments_parsed_from_segment_timeline() {
+        // Init segment + two <S> runs: (1 + 61) + (1 + 0) = 63 media segments.
+        let xml = r#"<MPD><Period><AdaptationSet><Representation codecs="flac">
+            <SegmentTemplate timescale="44100" initialization="https://cdn/init.mp4?t=1"
+              media="https://cdn/$Number$.mp4?t=1" startNumber="1">
+              <SegmentTimeline><S d="176128" r="61"/><S d="676"/></SegmentTimeline>
+            </SegmentTemplate></Representation></AdaptationSet></Period></MPD>"#;
+        let segs = parse_dash_segments(xml).expect("should parse");
+        assert_eq!(segs.len(), 64); // 1 init + 63 media
+        assert_eq!(segs[0], "https://cdn/init.mp4?t=1");
+        assert_eq!(segs[1], "https://cdn/1.mp4?t=1");
+        assert_eq!(segs[63], "https://cdn/63.mp4?t=1");
+    }
+
+    #[test]
+    fn dash_segments_none_without_segment_template() {
+        let xml = r#"<MPD><Period><BaseURL>https://cdn/single.flac</BaseURL></Period></MPD>"#;
+        assert!(parse_dash_segments(xml).is_none());
+    }
+
     #[test]
     fn all_artists_collected() {
         let t = parse(r#"{"id":1,"title":"Song","artists":[{"id":1,"name":"A"},{"id":2,"name":"B"},{"id":3,"name":"C"}],"album":{"id":100,"title":"Album"}}"#);
@@ -670,10 +846,18 @@ mod tests {
         let track_id = 86430568u64; // Netsky — Escape (known LOSSLESS track)
         let client = TidalClient::new(session.clone());
         let stream_info = client.stream_url(track_id).expect("stream_url failed");
+        let (url, encryption) = match stream_info {
+            StreamInfo::Single { url, encryption } => (url, encryption),
+            StreamInfo::Dash { segments } => {
+                println!("[2] DASH HiRes FLAC manifest — {} segments (init + media); \
+                          this test only covers the bts/decrypt path", segments.len());
+                return;
+            }
+        };
         println!("[2] stream_url OK");
-        println!("    url prefix  : {}", &stream_info.url[..stream_info.url.len().min(80)]);
-        println!("    encrypted   : {}", stream_info.encryption.is_some());
-        if let Some(ref enc) = stream_info.encryption {
+        println!("    url prefix  : {}", &url[..url.len().min(80)]);
+        println!("    encrypted   : {}", encryption.is_some());
+        if let Some(ref enc) = encryption {
             println!("    key  (hex)  : {}", enc.key.iter().map(|b| format!("{:02x}", b)).collect::<String>());
             println!("    nonce(hex)  : {}", enc.nonce.iter().map(|b| format!("{:02x}", b)).collect::<String>());
         }
@@ -682,7 +866,7 @@ mod tests {
         let http = reqwest::blocking::Client::builder()
             .user_agent(crate::auth::TIDAL_UA)
             .build().unwrap();
-        let mut resp = http.get(&stream_info.url)
+        let mut resp = http.get(&url)
             .header("Range", "bytes=0-262143")
             .send().expect("HTTP GET failed");
         println!("[3] HTTP {} content-length={:?}", resp.status(), resp.content_length());
@@ -693,7 +877,7 @@ mod tests {
         println!("    downloaded {} bytes", raw.len());
 
         // ── Step 4: decrypt (if needed) ───────────────────────────────────────
-        if let Some(enc) = stream_info.encryption {
+        if let Some(enc) = encryption {
             let mut iv = [0u8; 16];
             iv[..8].copy_from_slice(&enc.nonce);
             let mut cipher = Aes128Ctr::new_from_slices(&enc.key, &iv).expect("cipher init");

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use base64::Engine;
 use serde::Deserialize;
+use std::time::Duration;
 
 use crate::auth::Session;
 
@@ -145,6 +146,7 @@ impl From<RawTrack> for TrackInfo {
 
 // ─── Client ───────────────────────────────────────────────────────────────────
 
+#[derive(Clone)]
 pub struct TidalClient {
     pub session: Session,
     client: reqwest::blocking::Client,
@@ -154,6 +156,7 @@ impl TidalClient {
     pub fn new(session: Session) -> Self {
         let client = reqwest::blocking::Client::builder()
             .user_agent(crate::auth::TIDAL_UA)
+            .timeout(Duration::from_secs(30))
             .build()
             .unwrap_or_default();
         Self { session, client }
@@ -676,6 +679,7 @@ pub fn fetch_dash_flac(segments: &[String], dest: &std::path::Path) -> Result<()
     use std::io::Write;
     let http = reqwest::blocking::Client::builder()
         .user_agent(crate::auth::TIDAL_UA)
+        .timeout(Duration::from_secs(30))
         .build()?;
 
     let part = dest.with_extension("mp4.part");

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,11 @@ pub struct Config {
     pub calm_mode: bool,
     #[serde(default = "default_true")]
     pub show_controls_hint: bool,
+    /// Linux/macOS only: request HiRes lossless FLAC (via DASH, needs ffmpeg).
+    /// When off — or when ffmpeg isn't installed — falls back to MP4/AAC.
+    /// No effect on Windows, which always streams lossless FLAC.
+    #[serde(default = "default_true")]
+    pub hires_flac: bool,
 }
 
 fn default_search_limit() -> u32 { 10 }
@@ -50,6 +55,7 @@ impl Default for Config {
             pywal:              false,
             calm_mode:          false,
             show_controls_hint: true,
+            hires_flac:         true,
         }
     }
 }
@@ -181,6 +187,7 @@ pub fn edit_interactive() -> Result<()> {
             format!("Pywal colors        {}", if cfg.pywal          { "on" } else { "off" }),
             format!("Calm mode           {}", if cfg.calm_mode      { "on" } else { "off" }),
             format!("Controls hint       {}", if cfg.show_controls_hint { "on" } else { "off" }),
+            format!("HiRes FLAC          {}", if cfg.hires_flac        { "on" } else { "off" }),
             "Back".to_string(),
         ];
 
@@ -236,6 +243,7 @@ pub fn edit_interactive() -> Result<()> {
             4 => { cfg.pywal              = Confirm::new().with_prompt("Pywal colors").default(cfg.pywal).interact()?;                save(&cfg)?; }
             5 => { cfg.calm_mode          = Confirm::new().with_prompt("Calm mode").default(cfg.calm_mode).interact()?;               save(&cfg)?; }
             6 => { cfg.show_controls_hint = Confirm::new().with_prompt("Controls hint").default(cfg.show_controls_hint).interact()?;  save(&cfg)?; }
+            7 => { cfg.hires_flac         = Confirm::new().with_prompt("HiRes FLAC (Linux/macOS, needs ffmpeg)").default(cfg.hires_flac).interact()?; save(&cfg)?; }
             _ => break,
         }
     }

--- a/src/download_queue.rs
+++ b/src/download_queue.rs
@@ -115,81 +115,100 @@ fn download_track(entry: &QueueEntry, http: &reqwest::blocking::Client) {
         }
     };
 
-    // Download to .tmp, then detect actual format from magic bytes before finalising filename
-    let tmp_name = safe_filename(&format!("{} - {}.tmp", entry.track.artist_name, entry.track.title));
-    let tmp_path = out_dir.join(&tmp_name);
-
-    let resp = match http.get(&stream_info.url).send() {
-        Ok(r) => r,
-        Err(_) => return,
-    };
-    let mut f = match std::fs::File::create(&tmp_path) {
-        Ok(f) => f,
-        Err(_) => return,
-    };
-    let mut reader = match resp.error_for_status() {
-        Ok(r) => r,
-        Err(_) => {
-            let _ = std::fs::remove_file(&tmp_path);
-            return;
+    // Resolve the stream to a finished file on disk, handling both the single-URL
+    // (bts, maybe AES-encrypted) and multi-segment DASH (HiRes FLAC) cases.
+    let dest = match stream_info {
+        crate::api::StreamInfo::Dash { segments } => {
+            // HiRes FLAC: fetch every segment + remux to native .flac (lossless).
+            let filename = safe_filename(&format!(
+                "{} - {}.flac", entry.track.artist_name, entry.track.title
+            ));
+            let dest = out_dir.join(&filename);
+            if crate::api::fetch_dash_flac(&segments, &dest).is_err() {
+                let _ = std::fs::remove_file(&dest);
+                return;
+            }
+            dest
         }
-    };
+        crate::api::StreamInfo::Single { url, encryption } => {
+            // Download to .tmp, then detect actual format from magic bytes before finalising filename
+            let tmp_name = safe_filename(&format!("{} - {}.tmp", entry.track.artist_name, entry.track.title));
+            let tmp_path = out_dir.join(&tmp_name);
 
-    use ctr::cipher::{KeyIvInit, StreamCipher};
-    type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
-    let mut maybe_cipher = stream_info.encryption.map(|enc| {
-        let mut iv = [0u8; 16];
-        iv[..8].copy_from_slice(&enc.nonce);
-        Aes128Ctr::new_from_slices(&enc.key, &iv).expect("valid key/iv")
-    });
-
-    let mut buf = vec![0u8; 65_536];
-    let mut ok = true;
-    loop {
-        match reader.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => {
-                let chunk = &mut buf[..n];
-                if let Some(ref mut cipher) = maybe_cipher {
-                    cipher.apply_keystream(chunk);
+            let resp = match http.get(&url).send() {
+                Ok(r) => r,
+                Err(_) => return,
+            };
+            let mut f = match std::fs::File::create(&tmp_path) {
+                Ok(f) => f,
+                Err(_) => return,
+            };
+            let mut reader = match resp.error_for_status() {
+                Ok(r) => r,
+                Err(_) => {
+                    let _ = std::fs::remove_file(&tmp_path);
+                    return;
                 }
-                if f.write_all(chunk).is_err() {
-                    ok = false;
-                    break;
+            };
+
+            use ctr::cipher::{KeyIvInit, StreamCipher};
+            type Aes128Ctr = ctr::Ctr64BE<aes::Aes128>;
+            let mut maybe_cipher = encryption.map(|enc| {
+                let mut iv = [0u8; 16];
+                iv[..8].copy_from_slice(&enc.nonce);
+                Aes128Ctr::new_from_slices(&enc.key, &iv).expect("valid key/iv")
+            });
+
+            let mut buf = vec![0u8; 65_536];
+            let mut ok = true;
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let chunk = &mut buf[..n];
+                        if let Some(ref mut cipher) = maybe_cipher {
+                            cipher.apply_keystream(chunk);
+                        }
+                        if f.write_all(chunk).is_err() {
+                            ok = false;
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        ok = false;
+                        break;
+                    }
                 }
             }
-            Err(_) => {
-                ok = false;
-                break;
+            drop(f);
+
+            if !ok {
+                let _ = std::fs::remove_file(&tmp_path);
+                return;
             }
+
+            // Read magic bytes to determine actual container format
+            let ext = {
+                let mut magic = [0u8; 12];
+                let n = std::fs::File::open(&tmp_path)
+                    .and_then(|mut fh| fh.read(&mut magic))
+                    .unwrap_or(0);
+                crate::utils::audio_extension(&magic[..n])
+            };
+
+            let filename = safe_filename(&format!(
+                "{} - {}.{}",
+                entry.track.artist_name, entry.track.title, ext
+            ));
+            let dest = out_dir.join(&filename);
+
+            if std::fs::rename(&tmp_path, &dest).is_err() {
+                let _ = std::fs::remove_file(&tmp_path);
+                return;
+            }
+            dest
         }
-    }
-    drop(f);
-
-    if !ok {
-        let _ = std::fs::remove_file(&tmp_path);
-        return;
-    }
-
-    // Read magic bytes to determine actual container format
-    let ext = {
-        let mut magic = [0u8; 12];
-        let n = std::fs::File::open(&tmp_path)
-            .and_then(|mut fh| fh.read(&mut magic))
-            .unwrap_or(0);
-        crate::utils::audio_extension(&magic[..n])
     };
-
-    let filename = safe_filename(&format!(
-        "{} - {}.{}",
-        entry.track.artist_name, entry.track.title, ext
-    ));
-    let dest = out_dir.join(&filename);
-
-    if std::fs::rename(&tmp_path, &dest).is_err() {
-        let _ = std::fs::remove_file(&tmp_path);
-        return;
-    }
 
     let cover = entry.track.album_cover.as_deref()
         .and_then(|id| client.fetch_cover(id, 1280).ok());

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -486,22 +486,38 @@ pub fn run(
     let download_done = Arc::new(AtomicBool::new(false));
     let header_ready = Arc::new(AtomicBool::new(false));
 
-    let url_clone = stream_info.url.clone();
-    let enc_clone = stream_info.encryption;
-    let path_clone = tmp_path.clone();
-    let dd_clone = download_done.clone();
-    let hr_clone = header_ready.clone();
-
     let dl_bytes_shared = Arc::new(AtomicU64::new(0));
     let dl_total_shared = Arc::new(AtomicU64::new(0));
-    let dl_bytes_dl = dl_bytes_shared.clone();
-    let dl_total_dl = dl_total_shared.clone();
 
-    thread::spawn(move || {
-        download_to_file(&url_clone, &path_clone, &dd_clone, &hr_clone, &dl_bytes_dl, &dl_total_dl, enc_clone);
-    });
+    match stream_info {
+        crate::api::StreamInfo::Single { url, encryption } => {
+            // Single CDN URL: stream progressively into the temp file, decrypting
+            // on the fly, so playback can start before the download finishes.
+            let path_clone = tmp_path.clone();
+            let dd_clone = download_done.clone();
+            let hr_clone = header_ready.clone();
+            let dl_bytes_dl = dl_bytes_shared.clone();
+            let dl_total_dl = dl_total_shared.clone();
+            thread::spawn(move || {
+                download_to_file(&url, &path_clone, &dd_clone, &hr_clone, &dl_bytes_dl, &dl_total_dl, encryption);
+            });
+        }
+        crate::api::StreamInfo::Dash { segments } => {
+            // HiRes FLAC: ffmpeg needs the whole fragmented-MP4 before it can
+            // remux, so fetch every segment + remux to native FLAC, then play.
+            // (No progressive start for DASH — playback begins once remux is done.)
+            let path_clone = tmp_path.clone();
+            let dd_clone = download_done.clone();
+            let hr_clone = header_ready.clone();
+            thread::spawn(move || {
+                let _ = crate::api::fetch_dash_flac(&segments, &path_clone);
+                dd_clone.store(true, Ordering::Relaxed);   // file complete (or failed)
+                hr_clone.store(true, Ordering::Relaxed);   // release the wait below
+            });
+        }
+    }
 
-    // Wait until header bytes are ready
+    // Wait until the temp file is ready to probe/play
     loop {
         if header_ready.load(Ordering::Relaxed) { break; }
         thread::sleep(Duration::from_millis(50));

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -471,11 +471,8 @@ pub fn run(
         Err(e) => { teardown_terminal(&mut terminal); return Err(e); }
     };
 
-    // Fetch cover
-    let cover_bytes = track.album_cover.as_deref()
-        .and_then(|id| client.fetch_cover(id, 320).ok());
-
-    // Download to temp file in a background thread
+    // Download to temp file in a background thread. Started before the cover fetch
+    // (below) so the audio download — not a cover GET — is first on the wire.
     let tmp = match tempfile::Builder::new().suffix(".flac").tempfile() {
         Ok(t) => t,
         Err(e) => { teardown_terminal(&mut terminal); return Err(e.into()); }
@@ -503,19 +500,26 @@ pub fn run(
             });
         }
         crate::api::StreamInfo::Dash { segments } => {
-            // HiRes FLAC: ffmpeg needs the whole fragmented-MP4 before it can
-            // remux, so fetch every segment + remux to native FLAC, then play.
-            // (No progressive start for DASH — playback begins once remux is done.)
+            // HiRes FLAC: pipe DASH segments straight through ffmpeg and tee its
+            // FLAC output into the temp file as it arrives, so playback starts
+            // after the first frames instead of waiting for the whole track.
             let path_clone = tmp_path.clone();
             let dd_clone = download_done.clone();
             let hr_clone = header_ready.clone();
+            let dl_bytes_dl = dl_bytes_shared.clone();
             thread::spawn(move || {
-                let _ = crate::api::fetch_dash_flac(&segments, &path_clone);
-                dd_clone.store(true, Ordering::Relaxed);   // file complete (or failed)
-                hr_clone.store(true, Ordering::Relaxed);   // release the wait below
+                stream_dash_flac(&segments, &path_clone, &dd_clone, &hr_clone, &dl_bytes_dl);
             });
         }
     }
+
+    // Cover art: fetch on a background thread with a cloned client (cheap — the
+    // reqwest pool is shared via Arc) so the cover GET runs in parallel with the
+    // download warm-up instead of gating playback start. Joined just before play().
+    let cover_handle = track.album_cover.clone().map(|cover_id| {
+        let cover_client = client.clone();
+        thread::spawn(move || cover_client.fetch_cover(&cover_id, 320).ok())
+    });
 
     // Wait until the temp file is ready to probe/play
     loop {
@@ -535,6 +539,9 @@ pub fn run(
     let volume = shared_volume.unwrap_or_else(|| {
         Arc::new(Mutex::new(config::load().volume))
     });
+
+    // Cover is needed for rendering from here on; collect the background fetch.
+    let cover_bytes = cover_handle.and_then(|h| h.join().ok().flatten());
 
     let result = play(
         terminal,
@@ -644,6 +651,99 @@ fn download_to_file(
             }
         }
     }
+    header_ready.store(true, Ordering::Relaxed);
+    done.store(true, Ordering::Relaxed);
+}
+
+/// Progressive HiRes path. Download the DASH segments and feed them straight into
+/// ffmpeg, which stream-copies (`-c:a copy`) the fragmented-MP4 FLAC onto its
+/// stdout; we tee that growing FLAC stream into `path` as it is produced. This
+/// mirrors `download_to_file`'s progressive contract — `header_ready` fires once
+/// the first frames have landed, `done` at true EOF — so playback can begin in
+/// about a second instead of after the whole track downloads and remuxes.
+///
+/// A feeder thread writes ffmpeg's stdin while this thread drains its stdout, so
+/// neither pipe can deadlock. A fetch stall is bounded by a per-segment timeout;
+/// a missing/failed ffmpeg releases the wait immediately so the caller fails fast
+/// rather than hanging on a blank screen.
+fn stream_dash_flac(
+    segments: &[String],
+    path: &std::path::Path,
+    done: &AtomicBool,
+    header_ready: &AtomicBool,
+    dl_bytes: &AtomicU64,
+) {
+    use std::io::{Read, Write};
+    use std::process::{Command, Stdio};
+
+    let mut child = match Command::new("ffmpeg")
+        .args(["-v", "error", "-i", "pipe:0", "-c:a", "copy", "-f", "flac", "pipe:1"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => {
+            // ffmpeg unavailable: release the wait so run() proceeds and surfaces
+            // the failure instead of spinning forever on a blank screen.
+            header_ready.store(true, Ordering::Relaxed);
+            done.store(true, Ordering::Relaxed);
+            return;
+        }
+    };
+
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let mut stdout = child.stdout.take().expect("piped stdout");
+
+    // Feeder: pull each segment and write it into ffmpeg's stdin. A fetch error or
+    // broken pipe just ends the feed; dropping stdin signals EOF so ffmpeg
+    // finalises the FLAC stream and our stdout drain below sees true EOF.
+    let segs: Vec<String> = segments.to_vec();
+    let feeder = thread::spawn(move || {
+        let http = reqwest::blocking::Client::builder()
+            .user_agent(crate::auth::TIDAL_UA)
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
+        for seg in &segs {
+            match http.get(seg).send().and_then(|r| r.error_for_status()).and_then(|r| r.bytes()) {
+                Ok(bytes) => { if stdin.write_all(&bytes).is_err() { break; } }
+                Err(_) => break,
+            }
+        }
+        // stdin dropped here → ffmpeg sees EOF
+    });
+
+    let mut file = match fs::File::create(path) {
+        Ok(f) => f,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = feeder.join();
+            header_ready.store(true, Ordering::Relaxed);
+            done.store(true, Ordering::Relaxed);
+            return;
+        }
+    };
+    let mut written: u64 = 0;
+    let mut buf = vec![0u8; 65_536];
+    loop {
+        match stdout.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                let _ = file.write_all(&buf[..n]);
+                written += n as u64;
+                dl_bytes.store(written, Ordering::Relaxed);
+                if !header_ready.load(Ordering::Relaxed) && written >= BUFFER_THRESHOLD {
+                    header_ready.store(true, Ordering::Relaxed);
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    let _ = feeder.join();
+    let _ = child.wait();
     header_ready.store(true, Ordering::Relaxed);
     done.store(true, Ordering::Relaxed);
 }


### PR DESCRIPTION
## What

Adds lossless **HiRes FLAC** playback and downloads on Linux/macOS. Tidal serves HiRes-tagged tracks as unencrypted multi-segment DASH FLAC; this fetches the segments and remuxes them to native `.flac` with a stream-copy (`-c:a copy` — audio is never re-encoded).

- Opt-in via a `hires_flac` config setting (default on); falls back to the existing MP4/AAC path when disabled **or when ffmpeg isn't installed**, so there's no hard new dependency.
- `stream_url` requests `HI_RES_LOSSLESS` only when FLAC is enabled and ffmpeg is present; otherwise `HIGH` (unchanged behaviour). Windows is unaffected (still `LOSSLESS`).
- Saved files are named from the actual container magic bytes, so non-lossless tracks correctly land as `.m4a`.

## Performance

Playback starts promptly rather than after the whole track downloads and remuxes:

- DASH segments are piped straight through ffmpeg and the growing FLAC is teed to disk; playback is released once the first frames land (`stream_dash_flac`), mirroring the AAC path's progressive contract.
- Cover art is fetched on a background thread so the cover GET no longer gates audio start.
- 30s request timeout on the API and segment-fetch clients so a stalled CDN connection fails fast instead of hanging on a blank screen.

## Notes

- Requires `ffmpeg` on `PATH` for the FLAC path; gracefully degrades to AAC without it.
- Linux/macOS only — Windows already streams lossless FLAC.

## Test plan

- `cargo test` — all passing.
- Manual: HiRes track plays as FLAC and starts in ~1s; non-HiRes track falls back to AAC/`.m4a`; with ffmpeg removed, FLAC-enabled config still plays via AAC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)